### PR TITLE
added error message for non-displaying providers

### DIFF
--- a/src/Providers-page/ProvidersPage.tsx
+++ b/src/Providers-page/ProvidersPage.tsx
@@ -24,6 +24,7 @@ const ProvidersPage: React.FC = () => {
   const [mapAddress, setMapAddress] = useState<string>('Utah');
   const [isFiltered, setIsFiltered] = useState<boolean>(false);
   const [currentPage, setCurrentPage] = useState<number>(1);
+  const [showError, setShowError] = useState('');
 
   const mapSectionRef = useRef<HTMLDivElement>(null);
   const providersPerPage = 8;
@@ -41,8 +42,14 @@ const ProvidersPage: React.FC = () => {
         ));
         setUniqueInsuranceOptions(uniqueInsurances);
         setMapAddress('Utah');
+        if (mappedProviders.length === 0) {
+          setShowError('We are currently experiencing issues displaying ABA Providers. Please try again later.');
+        } else {
+          setShowError('');
+        }
       } catch (error) {
         console.error('Error loading providers:', error);
+        setShowError('We are currently experiencing issues displaying ABA Providers. Please try again later.');
       }
     };
 
@@ -285,7 +292,6 @@ const ProvidersPage: React.FC = () => {
             : `Showing ${allProviders.length} Providers`}
         </h2>
       </section>
-      
       <SearchBar
         onResults={handleResults}
         onSearch={handleSearch}
@@ -299,6 +305,8 @@ const ProvidersPage: React.FC = () => {
       />
 
       <section className="searched-provider-map-locations-list-section">
+      {showError && <div className='error-message'>{showError}</div>}
+
         <div className="provider-cards-grid">
           {paginatedProviders.map((provider, index) => (
             <ProviderCard


### PR DESCRIPTION
**What does this PR do?**

1. Adds error message when the API is possibly down or under maintenance so users know to try later. 

**Where should the reviewer start?**

### To start the app

- [ ]  Clone down the repository onto your local machine using `git clone <https://github.com/utah-aba-finder/utah-aba-finder-fe`>
- [ ]  Once cloned down, cd into the direction and install dependencies by running `npm install`
- [ ]  Run `npm start` then visit the local host to view the application in your browser.

### To test with Cypress

- [ ]  Type `npm install cypress --save-dev` into your terminal
- [ ]  Type `npm run cypress #` in your terminal then visit the local host to view the application in your browser.
- [ ]  Click E2E testing
- [ ]  Click Start E2E Testing in Chrome

**Screenshots**
<img width="1284" alt="Screenshot 2024-09-17 at 7 04 20 PM" src="https://github.com/user-attachments/assets/b339c17d-b227-43dc-9789-d9e00967c039">

