### PR TITLE
Iteration6/fe/cypress testing

### DIFF
--- a/cypress/e2e/provider-login.cy.ts
+++ b/cypress/e2e/provider-login.cy.ts
@@ -1,66 +1,92 @@
-describe('login page tests', () => {
-    beforeEach(() => {
-      cy.visit('http://localhost:3000/login')
-    })
-    it('should have a main header', () => {
-      cy.get('.loginImageText').should('contain', 'Provider Login')
-    })
-    it('should have a user icon', () => {
-      cy.get('.userIcon').should('exist')
-    })
-    it('should have a password icon', () => {
-      cy.get('.lockIcon').should('exist')
-    })
-    it('should have a password input', () => {
-      cy.get('#password').should('exist')
-    })
-    it('should have a username input', () => {
-      cy.get('#username').should('exist')
-    })
-    it('should have a submit button', () => {
-      cy.get('.loginButton').should('exist')
-    })
-    it('should have a sign up button for no existent users', () => {
-      cy.get('.loginButton').should('exist')
-    })
-    it('should have a forgot password link', () => {
-      cy.get('.forgot-password').should('exist')
-    })
-    it('should have a eye button to show password', () => {
-      cy.get('.eyeButton').should('exist')
-    })
-    it('should have a eye icon', () => {
-      cy.get('.eye').should('exist')
-    })
-    it('should require a username and password', () => {
-      cy.get('#login').should('be.enabled')
-      .click()
-      cy.get('#username').should('have.attr', 'required');
-  
-      cy.get('#password').should('have.attr', 'required');
-    })
-    it('should show password when eye button is clicked', () => {
-      cy.get('.eyeButton').click()
-      cy.get('#password').should('have.attr', 'type', 'text')
-    })
-    it('should redirect to signup page when sign up button is clicked', () => {
-      cy.get('#signup').click()
-      cy.url().should('include', '/signup')
-    })
-    it.skip('should redirect to forgot password page when forgot password link is clicked', () => {
-      cy.get('.forgot-password').click()
-      cy.url().should('include', '/forgot-password')
-    })
-    it.skip('should throw an error when the user does not exist', () => {
-      cy.get('#username').type('user')
-      cy.get('#password').type('password')
-      cy.get('#login').click()
-      cy.get('.error').should('exist')
-    })
-    it.skip('should redirect to providers info page when login is successful', () => {
-      cy.get('#username').type('user')
-      cy.get('#password').type('password')
-      cy.get('#login').click()
-      cy.url().should('include', '/user:id')
-    })
+describe('Providers Page', () => {
+  beforeEach(() => {
+    cy.setUpIntercepts(1);
+    cy.visit('http://localhost:3000/login');
   })
+
+  // it('should have a main header', () => {
+  //   cy.get('.loginImageText').should('contain', 'Provider Login')
+  // })
+  // it('should have a user icon', () => {
+  //   cy.get('.userIcon').should('exist')
+  // })
+  // it('should have a password icon', () => {
+  //   cy.get('.lockIcon').should('exist')
+  // })
+  // it('should have a password input', () => {
+  //   cy.get('#password').should('exist')
+  // })
+  // it('should have a username input', () => {
+  //   cy.get('#username').should('exist')
+  // })
+  // it('should have a submit button', () => {
+  //   cy.get('.loginButton').should('exist')
+  // })
+  // it('should have a sign up button for no existent users', () => {
+  //   cy.get('.loginButton').should('exist')
+  // })
+  // it('should have a forgot password link', () => {
+  //   cy.get('.forgot-password').should('exist')
+  // })
+  // it('should have a eye button to show password', () => {
+  //   cy.get('.eyeButton').should('exist')
+  // })
+  // it('should have a eye icon', () => {
+  //   cy.get('.eye').should('exist')
+  // })
+  // it('should require a username and password', () => {
+  //   cy.get('#login').should('be.enabled')
+  //     .click()
+  //   cy.get('#username').should('have.attr', 'required');
+
+  //   cy.get('#password').should('have.attr', 'required');
+  // })
+
+  it('should be able to log a Provider in and show their data', () => {
+    cy.get('#username').type('test@test.com');
+    cy.get('#password').type('password');
+    cy.get('#login').click();
+  
+    cy.wait('@postLogin').then((interception) => {
+      console.log('Post Login Interception:', interception); // Full interception object
+      expect(interception.response.statusCode).to.eq(200);
+      
+      const authHeader = interception.response.headers['Authorization']; // Use capital 'A'
+      console.log('Authorization Header:', authHeader); // Log header
+  
+      expect(authHeader).to.eq('Bearer mock-auth-token'); // Check the header
+      window.sessionStorage.setItem('authToken', 'mock-auth-token'); // Set token for further requests
+    });
+  
+    cy.wait('@fetchSingleProvider').then((interception) => {
+      expect(interception.response.statusCode).to.eq(200);
+      expect(interception.response.body.data[0].attributes).to.have.property('name', 'A BridgeCare ABA');
+    });
+  });
+  
+  
+  
+  
+
+
+  // it.skip('should redirect to signup page when sign up button is clicked', () => {
+  //   cy.get('#signup').click()
+  //   cy.url().should('include', '/signup')
+  // })
+  // it.skip('should redirect to forgot password page when forgot password link is clicked', () => {
+  //   cy.get('.forgot-password').click()
+  //   cy.url().should('include', '/forgot-password')
+  // })
+  // it.skip('should throw an error when the user does not exist', () => {
+  //   cy.get('#username').type('user')
+  //   cy.get('#password').type('password')
+  //   cy.get('#login').click()
+  //   cy.get('.error').should('exist')
+  // })
+  // it.skip('should redirect to providers info page when login is successful', () => {
+  //   cy.get('#username').type('user')
+  //   cy.get('#password').type('password')
+  //   cy.get('#login').click()
+  //   cy.url().should('include', '/user:id')
+  // })
+})

--- a/cypress/e2e/provider-login.cy.ts
+++ b/cypress/e2e/provider-login.cy.ts
@@ -4,89 +4,100 @@ describe('Providers Page', () => {
     cy.visit('http://localhost:3000/login');
   })
 
-  // it('should have a main header', () => {
-  //   cy.get('.loginImageText').should('contain', 'Provider Login')
-  // })
-  // it('should have a user icon', () => {
-  //   cy.get('.userIcon').should('exist')
-  // })
-  // it('should have a password icon', () => {
-  //   cy.get('.lockIcon').should('exist')
-  // })
-  // it('should have a password input', () => {
-  //   cy.get('#password').should('exist')
-  // })
-  // it('should have a username input', () => {
-  //   cy.get('#username').should('exist')
-  // })
-  // it('should have a submit button', () => {
-  //   cy.get('.loginButton').should('exist')
-  // })
-  // it('should have a sign up button for no existent users', () => {
-  //   cy.get('.loginButton').should('exist')
-  // })
-  // it('should have a forgot password link', () => {
-  //   cy.get('.forgot-password').should('exist')
-  // })
-  // it('should have a eye button to show password', () => {
-  //   cy.get('.eyeButton').should('exist')
-  // })
-  // it('should have a eye icon', () => {
-  //   cy.get('.eye').should('exist')
-  // })
-  // it('should require a username and password', () => {
-  //   cy.get('#login').should('be.enabled')
-  //     .click()
-  //   cy.get('#username').should('have.attr', 'required');
+  it('should have a main header', () => {
+    cy.get('.loginImageText').should('contain', 'Provider Login')
+  })
+  it('should have a user icon', () => {
+    cy.get('.userIcon').should('exist')
+  })
+  it('should have a password icon', () => {
+    cy.get('.lockIcon').should('exist')
+  })
+  it('should have a password input', () => {
+    cy.get('#password').should('exist')
+  })
+  it('should have a username input', () => {
+    cy.get('#username').should('exist')
+  })
+  it('should have a submit button', () => {
+    cy.get('.loginButton').should('exist')
+  })
+  it('should have a sign up button for no existent users', () => {
+    cy.get('.loginButton').should('exist')
+  })
+  it('should have a forgot password link', () => {
+    cy.get('.forgot-password').should('exist')
+  })
+  it('should have a eye button to show password', () => {
+    cy.get('.eyeButton').should('exist')
+  })
+  it('should have a eye icon', () => {
+    cy.get('.eye').should('exist')
+  })
+  it('should require a username and password', () => {
+    cy.get('#login').should('be.enabled')
+      .click()
+    cy.get('#username').should('have.attr', 'required');
 
-  //   cy.get('#password').should('have.attr', 'required');
-  // })
+    cy.get('#password').should('have.attr', 'required');
+  })
 
-  it('should be able to log a Provider in and show their data', () => {
+  it.skip('should redirect to signup page when sign up button is clicked', () => {
+    cy.get('#signup').click()
+    cy.url().should('include', '/signup')
+  })
+  it.skip('should redirect to forgot password page when forgot password link is clicked', () => {
+    cy.get('.forgot-password').click()
+    cy.url().should('include', '/forgot-password')
+  })
+  it.skip('should throw an error when the user does not exist', () => {
+    cy.get('#username').type('user')
+    cy.get('#password').type('password')
+    cy.get('#login').click()
+    cy.get('.error').should('exist')
+  })
+  it.skip('should redirect to providers info page when login is successful', () => {
+    cy.get('#username').type('user')
+    cy.get('#password').type('password')
+    cy.get('#login').click()
+    cy.url().should('include', '/user:id')
+  })
+
+
+
+  it('should log a Provider in and display their information correctly', () => {
     cy.get('#username').type('test@test.com');
     cy.get('#password').type('password');
     cy.get('#login').click();
-  
+
     cy.wait('@postLogin').then((interception) => {
-      console.log('Post Login Interception:', interception); // Full interception object
       expect(interception.response.statusCode).to.eq(200);
-      
-      const authHeader = interception.response.headers['Authorization']; // Use capital 'A'
-      console.log('Authorization Header:', authHeader); // Log header
-  
-      expect(authHeader).to.eq('Bearer mock-auth-token'); // Check the header
-      window.sessionStorage.setItem('authToken', 'mock-auth-token'); // Set token for further requests
+      const authHeader = interception.response.headers['Authorization'];
+      expect(authHeader).to.eq('Bearer mock-auth-token');
+      window.sessionStorage.setItem('authToken', 'mock-auth-token');
     });
-  
+
     cy.wait('@fetchSingleProvider').then((interception) => {
       expect(interception.response.statusCode).to.eq(200);
-      expect(interception.response.body.data[0].attributes).to.have.property('name', 'A BridgeCare ABA');
+      expect(interception.response.body.data[0].attributes).to.have.property('name', 'Affinity Autism Services');
     });
+
+    cy.get('.user-info-section h1').should('contain', 'Welcome, Affinity Autism Services');
+    cy.get('#dropdown-menu').should('exist');
+    cy.get('#dropdown-menu').select('Select location').should('have.value', '');
+    cy.get('input[name="website"]').should('have.value', 'www.affinityautism.com');
+    cy.get('input[name="spanish"]').should('have.value', 'limited');
+    cy.get('input[name="min_age"]').should('have.value', '1.5');
+    cy.get('input[name="max_age"]').should('have.value', '21');
+    cy.get('input[name="waitlist"]').should('have.value', '12 months');
+    cy.get('input[name="clinicServices"]').should('have.value', 'Yes');
+    cy.get('input[name="homeServices"]').should('have.value', 'No');
+    cy.get('input[name="telehealthServices"]').should('have.value', 'limited');
+
+    cy.get('.select-insurance-button').should('exist').and('contain', 'Select Insurance Coverage');
+    cy.get('.select-counties-button').should('exist').and('contain', 'Select Counties');
+
+    cy.get('.save-button').should('exist').and('contain', 'Save');
+    cy.get('.cancel-button').should('exist').and('contain', 'Cancel');
   });
-  
-  
-  
-  
-
-
-  // it.skip('should redirect to signup page when sign up button is clicked', () => {
-  //   cy.get('#signup').click()
-  //   cy.url().should('include', '/signup')
-  // })
-  // it.skip('should redirect to forgot password page when forgot password link is clicked', () => {
-  //   cy.get('.forgot-password').click()
-  //   cy.url().should('include', '/forgot-password')
-  // })
-  // it.skip('should throw an error when the user does not exist', () => {
-  //   cy.get('#username').type('user')
-  //   cy.get('#password').type('password')
-  //   cy.get('#login').click()
-  //   cy.get('.error').should('exist')
-  // })
-  // it.skip('should redirect to providers info page when login is successful', () => {
-  //   cy.get('#username').type('user')
-  //   cy.get('#password').type('password')
-  //   cy.get('#login').click()
-  //   cy.url().should('include', '/user:id')
-  // })
 })

--- a/cypress/e2e/providermodal.cy.ts
+++ b/cypress/e2e/providermodal.cy.ts
@@ -1,6 +1,6 @@
 describe('Providers Page', () => {
   beforeEach(() => {
-    cy.setUpProvidersIntercepts();
+    // cy.setUpProvidersIntercepts();
     cy.visit('http://localhost:3000/providers');
   })
   it('displays the first Providers details and be able to click on View Details to bring up the Providers Modal', () => {

--- a/cypress/e2e/providerspage.cy.ts
+++ b/cypress/e2e/providerspage.cy.ts
@@ -1,6 +1,6 @@
 describe('Providers Page', () => {
   beforeEach(() => {
-    cy.setUpProvidersIntercepts();
+    cy.setUpIntercepts();
     cy.visit('http://localhost:3000/providers');
   })
 
@@ -43,7 +43,7 @@ describe('Providers Page', () => {
 
 
 
- it('displays the first and last Provider card with correct details', () => {
+  it('displays the first and last Provider card with correct details', () => {
 
     cy.get('.searched-provider-card').first().within(() => {
       cy.get('h3').should('contain.text', 'Catalyst Behavior Solutions');
@@ -64,9 +64,6 @@ describe('Providers Page', () => {
       cy.get('select.view-on-map-dropdown')
         .should('contain.text', 'Select Location to View on Map');
     });
-  });
-})
-     
 
     cy.get('.searched-provider-card').last().within(() => {
       cy.get('h3').should('contain.text', 'ABS Kids');
@@ -92,166 +89,168 @@ describe('Providers Page', () => {
       cy.get('select.view-on-map-dropdown').select(3);
     });
 
-  it('should load Google Maps with the correct address after selecting Davis County Office', () => {
-    cy.get('.searched-provider-card').last().within(() => {
-      cy.get('select.view-on-map-dropdown').select(3);
+    it('should load Google Maps with the correct address after selecting Davis County Office', () => {
+      cy.get('.searched-provider-card').last().within(() => {
+        cy.get('select.view-on-map-dropdown').select(3);
+      });
+
+      cy.get('.google-map-section').scrollIntoView();
+
+      cy.get('.google-map-section')
+        .should('exist')
+        .and('be.visible');
+
+      cy.wait('@googleMapsEmbed').then((interception) => {
+        cy.get('body').should('contain', '2940 Church St, Layton, UT 84040');
+      });
     });
 
-    cy.get('.google-map-section').scrollIntoView();
 
-    cy.get('.google-map-section')
-      .should('exist')
-      .and('be.visible');
+    it('should have a functional Search Bar that can apply each search parameter to narrow down results and reset', () => {
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 8 of 8 Providers');
 
-    cy.wait('@googleMapsEmbed').then((interception) => {
-      cy.get('body').should('contain', '2940 Church St, Layton, UT 84040');
+      cy.get('.provider-county-select')
+        .should('exist')
+        .find('option')
+        .should('have.length.greaterThan', 12);
+
+      cy.get('.provider-county-select')
+        .select(18);
+      cy.get('.provider-search-button').click();
+
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 5 of 5 Providers');
+
+      cy.get('.searched-provider-card').first().within(() => {
+        cy.get('h3').should('contain.text', 'Above & Beyond Therapy');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Phone: (801) 630-2040');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Email: info@abtaba.com');
+        cy.get('h4')
+          .should('contain.text', '1234 West Road Drive');
+      });
+
+      cy.get('.provider-insurance-select')
+        .should('exist')
+        .find('option')
+        .should('have.length.greaterThan', 12);
+
+      cy.get('.provider-insurance-select')
+        .select(18);
+      cy.get('.provider-search-button').click();
+
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 2 of 2 Providers');
+
+      cy.get('.searched-provider-card').first().within(() => {
+        cy.get('h3').should('contain.text', 'A.B.I. Learning Center');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Phone: (801) 998-8428');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Email: Office@abilearningcenter.com');
+        cy.get('h4')
+          .should('contain.text', '12637 S 265 W');
+      });
+      cy.get('.provider-map-searchbar input[type="text"]').type('learn');
+
+      cy.get('.searched-provider-card').first().within(() => {
+        cy.get('h3').should('contain.text', 'A.B.I. Learning Center');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Phone: (801) 998-8428');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Email: Office@abilearningcenter.com');
+        cy.get('h4')
+          .should('contain.text', '12637 S 265 W');
+      });
+
+      cy.get('.provider-reset-button').click();
+
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 8 Providers');
+    });
+
+    it('should be able to filter Spanish, Services, and Waitlist and reset', () => {
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 8 of 8 Providers');
+
+      cy.get('.provider-spanish-select')
+        .should('exist')
+        .find('option')
+        .should('have.length.greaterThan', 1);
+
+      cy.get('.provider-spanish-select')
+        .select(1);
+      cy.get('.provider-search-button').click();
+
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 6 of 6 Providers');
+
+      cy.get('.searched-provider-card').first().within(() => {
+        cy.get('h3').should('contain.text', 'Catalyst Behavior Solutions');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Phone: 1-866-569-7395');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Email: austismspecialist@gmail.com');
+        cy.get('h4')
+          .should('contain.text', '6033 Fashion Point Dr');
+      });
+
+      cy.get('.provider-service-select')
+        .should('exist')
+        .find('option')
+        .should('have.length.greaterThan', 1);
+
+      cy.get('.provider-service-select')
+        .select(2);
+      cy.get('.provider-search-button').click();
+
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 4 of 4 Providers');
+
+      cy.get('.provider-waitlist-select')
+        .should('exist')
+        .find('option')
+        .should('have.length.greaterThan', 1);
+
+      cy.get('.provider-waitlist-select')
+        .select(1);
+      cy.get('.provider-search-button').click();
+
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 1 of 1 Providers');
+
+      cy.get('.searched-provider-card').first().within(() => {
+        cy.get('h3').should('contain.text', 'ABA Pediatric Autism Services');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Phone: (801) 477-5177');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Email: info@abapediatricautismservices.com');
+        cy.get('h4')
+          .should('contain.text', '744 E 400 S');
+      });
+
+      cy.get('.provider-map-searchbar input[type="text"]').type('Pediatric');
+      cy.get('.provider-search-button').click();
+
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 1 of 1 Providers');
+
+      cy.get('.searched-provider-card').first().within(() => {
+        cy.get('h3').should('contain.text', 'ABA Pediatric Autism Services');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Phone: (801) 477-5177');
+        cy.get('.searched-provider-card-info')
+          .should('contain.text', 'Email: info@abapediatricautismservices.com');
+        cy.get('h4')
+          .should('contain.text', '744 E 400 S');
+      });
+
+      cy.get('.provider-reset-button').click();
+
+      cy.get('.provider-title-section')
+        .should('contain.text', 'Showing 8 Providers');
     });
   });
-
-
-  it('should have a functional Search Bar that can apply each search parameter to narrow down results and reset', () => {
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 8 of 8 Providers');
-
-    cy.get('.provider-county-select')
-      .should('exist')
-      .find('option')
-      .should('have.length.greaterThan', 12);
-
-    cy.get('.provider-county-select')
-      .select(18);
-    cy.get('.provider-search-button').click();
-
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 5 of 5 Providers');
-
-    cy.get('.searched-provider-card').first().within(() => {
-      cy.get('h3').should('contain.text', 'Above & Beyond Therapy');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Phone: (801) 630-2040');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Email: info@abtaba.com');
-      cy.get('h4')
-        .should('contain.text', '1234 West Road Drive');
-    });
-
-    cy.get('.provider-insurance-select')
-      .should('exist')
-      .find('option')
-      .should('have.length.greaterThan', 12);
-
-    cy.get('.provider-insurance-select')
-      .select(18);
-    cy.get('.provider-search-button').click();
-
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 2 of 2 Providers');
-
-    cy.get('.searched-provider-card').first().within(() => {
-      cy.get('h3').should('contain.text', 'A.B.I. Learning Center');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Phone: (801) 998-8428');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Email: Office@abilearningcenter.com');
-      cy.get('h4')
-        .should('contain.text', '12637 S 265 W');
-    });
-    cy.get('.provider-map-searchbar input[type="text"]').type('learn');
-
-    cy.get('.searched-provider-card').first().within(() => {
-      cy.get('h3').should('contain.text', 'A.B.I. Learning Center');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Phone: (801) 998-8428');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Email: Office@abilearningcenter.com');
-      cy.get('h4')
-        .should('contain.text', '12637 S 265 W');
-    });
-
-    cy.get('.provider-reset-button').click();
-
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 8 Providers');
-  });
-
-  it('should be able to filter Spanish, Services, and Waitlist and reset', () => {
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 8 of 8 Providers');
-
-    cy.get('.provider-spanish-select')
-      .should('exist')
-      .find('option')
-      .should('have.length.greaterThan', 1);
-
-    cy.get('.provider-spanish-select')
-      .select(1);
-    cy.get('.provider-search-button').click();
-
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 6 of 6 Providers');
-
-    cy.get('.searched-provider-card').first().within(() => {
-      cy.get('h3').should('contain.text', 'Catalyst Behavior Solutions');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Phone: 1-866-569-7395');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Email: austismspecialist@gmail.com');
-      cy.get('h4')
-        .should('contain.text', '6033 Fashion Point Dr');
-    });
-
-    cy.get('.provider-service-select')
-      .should('exist')
-      .find('option')
-      .should('have.length.greaterThan', 1);
-
-    cy.get('.provider-service-select')
-      .select(2);
-    cy.get('.provider-search-button').click();
-
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 4 of 4 Providers');
-
-    cy.get('.provider-waitlist-select')
-      .should('exist')
-      .find('option')
-      .should('have.length.greaterThan', 1);
-
-    cy.get('.provider-waitlist-select')
-      .select(1);
-    cy.get('.provider-search-button').click();
-
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 1 of 1 Providers');
-
-    cy.get('.searched-provider-card').first().within(() => {
-      cy.get('h3').should('contain.text', 'ABA Pediatric Autism Services');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Phone: (801) 477-5177');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Email: info@abapediatricautismservices.com');
-      cy.get('h4')
-        .should('contain.text', '744 E 400 S');
-    });
-
-    cy.get('.provider-map-searchbar input[type="text"]').type('Pediatric');
-    cy.get('.provider-search-button').click();
-
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 1 of 1 Providers');
-
-    cy.get('.searched-provider-card').first().within(() => {
-      cy.get('h3').should('contain.text', 'ABA Pediatric Autism Services');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Phone: (801) 477-5177');
-      cy.get('.searched-provider-card-info')
-        .should('contain.text', 'Email: info@abapediatricautismservices.com');
-      cy.get('h4')
-        .should('contain.text', '744 E 400 S');
-    });
-
-    cy.get('.provider-reset-button').click();
-
-    cy.get('.provider-title-section')
-      .should('contain.text', 'Showing 8 Providers');
-  });
+});

--- a/cypress/fixtures/loginPost.json
+++ b/cypress/fixtures/loginPost.json
@@ -1,0 +1,8 @@
+{
+    "data": {
+        "id": 1,
+        "email": "test@test.com",
+        "created_at": "2024-09-15T21:42:30.145Z",
+        "created_date": "09/15/2024"
+    }
+}

--- a/cypress/fixtures/loginPost.json
+++ b/cypress/fixtures/loginPost.json
@@ -1,8 +1,0 @@
-{
-    "data": {
-        "id": 1,
-        "email": "test@test.com",
-        "created_at": "2024-09-15T21:42:30.145Z",
-        "created_date": "09/15/2024"
-    }
-}

--- a/cypress/fixtures/mockToken.json
+++ b/cypress/fixtures/mockToken.json
@@ -1,0 +1,3 @@
+{
+    "token": "mock-auth-token"
+  }

--- a/cypress/fixtures/providerspage.json
+++ b/cypress/fixtures/providerspage.json
@@ -14,8 +14,6 @@
                         "state": "UT",
                         "zip": "84403",
                         "phone": "1-866-569-7395"
-<<<<<<< HEAD
-<<<<<<< HEAD
                     },
                     {
                         "name": "Farmington",
@@ -28,18 +26,7 @@
                     }
                 ],
                 "website": "https://catalystbehavior.com/",
-                "email": null,
-=======
-=======
->>>>>>> 6bc7399151c507ac204731cf8e82592cc1ea3022
-                    }
-                ],
-                "website": "https://catalystbehavior.com/",
                 "email": "austismspecialist@gmail.com",
-<<<<<<< HEAD
->>>>>>> 4fe5d0604359cd4a2d0fffb762ce84de991a4e8a
-=======
->>>>>>> 6bc7399151c507ac204731cf8e82592cc1ea3022
                 "cost": "Discount offered for prepaying services\r\n RBT $80, $64 with prepay discount. BCaBA/student\r\n $100, $80 with prepay discount BCBA $150, $120\r\n with prepay\r\n discount.",
                 "insurance": [
                     {
@@ -83,25 +70,11 @@
                 "locations": [
                     {
                         "name": "https://www.abtaba.com/locations/aba-therapy-in-utah",
-<<<<<<< HEAD
-<<<<<<< HEAD
-                        "address_1": null,
-                        "address_2": null,
-                        "city": null,
-                        "state": null,
-                        "zip": null,
-=======
-=======
->>>>>>> 6bc7399151c507ac204731cf8e82592cc1ea3022
                         "address_1": "1234 West Road Drive",
                         "address_2": null,
                         "city": "Mockville",
                         "state": "Mocka",
                         "zip": "32465",
-<<<<<<< HEAD
->>>>>>> 4fe5d0604359cd4a2d0fffb762ce84de991a4e8a
-=======
->>>>>>> 6bc7399151c507ac204731cf8e82592cc1ea3022
                         "phone": "(801) 630-2040"
                     }
                 ],

--- a/cypress/fixtures/singleProvider.json
+++ b/cypress/fixtures/singleProvider.json
@@ -4,38 +4,80 @@
             "id": 1,
             "type": "provider",
             "attributes": {
-                "name": "A BridgeCare ABA",
+                "name": "Affinity Autism Services",
                 "locations": [
                     {
-                        "name": "https://www.bridgecareaba.com/locations/aba-therapy-in-utah",
-                        "address_1": null,
+                        "name": null,
+                        "address_1": "1970 W 7800 S",
                         "address_2": null,
-                        "city": null,
-                        "state": null,
-                        "zip": null,
-                        "phone": "801-435-8088"
+                        "city": "West Jordan",
+                        "state": "UT",
+                        "zip": "84088",
+                        "phone": "(801) 506-6695"
                     }
                 ],
-                "website": "https://www.bridgecareaba.com/locations/utah",
-                "email": "info@bridgecareaba.com",
-                "cost": "N/A",
+                "website": "www.affinityautism.com",
+                "email": "Affinity@affinitytreatment.com",
+                "cost": "Private pay rates available upon request",
                 "insurance": [
+                    {
+                        "name": "Meritain (Aetna)"
+                    },
+                    {
+                        "name": "Anthem (BCBS)"
+                    },
+                    {
+                        "name": "Regence (BCBS)"
+                    },
+                    {
+                        "name": "Cigna"
+                    },
+                    {
+                        "name": "Compsych"
+                    },
+                    {
+                        "name": "Deseret Mutual Benefit Administrators (DMBA)"
+                    },
+                    {
+                        "name": "EMI Health"
+                    },
+                    {
+                        "name": "Medicaid"
+                    },
+                    {
+                        "name": "MotivHealth"
+                    },
+                    {
+                        "name": "Select Health"
+                    },
+                    {
+                        "name": "UMR (UHC)"
+                    },
+                    {
+                        "name": "United HealthCare (UHC)"
+                    },
+                    {
+                        "name": "University of Utah Health Plans"
+                    },
+                    {
+                        "name": "Utah’s Children’s Health Insurance Program (CHIP)"
+                    },
                     {
                         "name": "Contact us"
                     }
                 ],
                 "counties_served": [
                     {
-                        "county": "Salt Lake, Utah, Davis, Weber"
+                        "county": "Utah, Salt Lake, Iron, Davis, Weber"
                     }
                 ],
-                "min_age": 2.0,
-                "max_age": 16.0,
-                "waitlist": "No",
-                "telehealth_services": "Yes",
-                "spanish_speakers": "Yes",
-                "at_home_services": null,
-                "in_clinic_services": null
+                "min_age": 1.5,
+                "max_age": 21.0,
+                "waitlist": "12 months",
+                "telehealth_services": "limited",
+                "spanish_speakers": "limited",
+                "at_home_services": "No",
+                "in_clinic_services": "Yes"
             }
         }
     ]

--- a/cypress/fixtures/singleProvider.json
+++ b/cypress/fixtures/singleProvider.json
@@ -1,0 +1,42 @@
+{
+    "data": [
+        {
+            "id": 1,
+            "type": "provider",
+            "attributes": {
+                "name": "A BridgeCare ABA",
+                "locations": [
+                    {
+                        "name": "https://www.bridgecareaba.com/locations/aba-therapy-in-utah",
+                        "address_1": null,
+                        "address_2": null,
+                        "city": null,
+                        "state": null,
+                        "zip": null,
+                        "phone": "801-435-8088"
+                    }
+                ],
+                "website": "https://www.bridgecareaba.com/locations/utah",
+                "email": "info@bridgecareaba.com",
+                "cost": "N/A",
+                "insurance": [
+                    {
+                        "name": "Contact us"
+                    }
+                ],
+                "counties_served": [
+                    {
+                        "county": "Salt Lake, Utah, Davis, Weber"
+                    }
+                ],
+                "min_age": 2.0,
+                "max_age": 16.0,
+                "waitlist": "No",
+                "telehealth_services": "Yes",
+                "spanish_speakers": "Yes",
+                "at_home_services": null,
+                "in_clinic_services": null
+            }
+        }
+    ]
+}

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -25,7 +25,7 @@ Cypress.Commands.add('setUpIntercepts', (providerId) => {
     req.reply({
       statusCode: 200,
       headers: {
-        'Authorization': 'Bearer mock-auth-token', // Make sure this line is present
+        'Authorization': 'Bearer mock-auth-token',
       },
       body: {
         status: {
@@ -43,10 +43,6 @@ Cypress.Commands.add('setUpIntercepts', (providerId) => {
     });
   }).as('postLogin');
   
-  
-  
-  
-
   cy.intercept('GET', `https://uta-aba-finder-be-97eec9f967d0.herokuapp.com/api/v1/providers/${providerId}`, (req) => {
     const token = window.sessionStorage.getItem('authToken');
     if (req.headers.authorization === `Bearer ${token}`) {
@@ -56,12 +52,9 @@ Cypress.Commands.add('setUpIntercepts', (providerId) => {
       });
     } else {
       req.reply({
-        statusCode: 401,  // Unauthorized if token is missing or incorrect
+        statusCode: 401, 
         body: { error: 'Unauthorized' }
       });
     }
   }).as('fetchSingleProvider');
-  
-  
-
 });

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -1,15 +1,5 @@
-Cypress.Commands.add('setUpProvidersIntercepts', () => {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    cy.intercept('GET', 'https://uta-aba-finder-be-97eec9f967d0.herokuapp.com/api/v1/providers', {
-      statusCode: 200,
-      fixture: 'providerspage.json',
-    }).as('fetchProviders');
-  });
-=======
-=======
->>>>>>> 6bc7399151c507ac204731cf8e82592cc1ea3022
-  // Intercept the API call for providers
+// commands.js
+Cypress.Commands.add('setUpIntercepts', (providerId) => {
   cy.intercept('GET', 'https://uta-aba-finder-be-97eec9f967d0.herokuapp.com/api/v1/providers', {
     statusCode: 200,
     fixture: 'providerspage.json',
@@ -17,7 +7,6 @@ Cypress.Commands.add('setUpProvidersIntercepts', () => {
 
   cy.intercept('GET', '**/maps/embed/v1/place**', (req) => {
     const address = req.query.q;
-
     req.reply({
       statusCode: 200,
       headers: { 'content-type': 'text/html' },
@@ -31,8 +20,48 @@ Cypress.Commands.add('setUpProvidersIntercepts', () => {
       `,
     });
   }).as('googleMapsEmbed');
+
+  cy.intercept('POST', 'https://uta-aba-finder-be-97eec9f967d0.herokuapp.com/login', (req) => {
+    req.reply({
+      statusCode: 200,
+      headers: {
+        'Authorization': 'Bearer mock-auth-token', // Make sure this line is present
+      },
+      body: {
+        status: {
+          code: 200,
+          message: "Logged in successfully"
+        },
+        data: {
+          id: 1,
+          email: "test@test.com",
+          created_at: "2024-09-17T19:01:50.233Z",
+          provider_id: null,
+          created_date: "09/17/2024"
+        }
+      }
+    });
+  }).as('postLogin');
+  
+  
+  
+  
+
+  cy.intercept('GET', `https://uta-aba-finder-be-97eec9f967d0.herokuapp.com/api/v1/providers/${providerId}`, (req) => {
+    const token = window.sessionStorage.getItem('authToken');
+    if (req.headers.authorization === `Bearer ${token}`) {
+      req.reply({
+        statusCode: 200,
+        fixture: 'singleProvider.json'
+      });
+    } else {
+      req.reply({
+        statusCode: 401,  // Unauthorized if token is missing or incorrect
+        body: { error: 'Unauthorized' }
+      });
+    }
+  }).as('fetchSingleProvider');
+  
+  
+
 });
-<<<<<<< HEAD
->>>>>>> 4fe5d0604359cd4a2d0fffb762ce84de991a4e8a
-=======
->>>>>>> 6bc7399151c507ac204731cf8e82592cc1ea3022

--- a/src/Provider-login/LoginPage.css
+++ b/src/Provider-login/LoginPage.css
@@ -102,12 +102,10 @@
 .eyeButton {
     position: absolute;
     right: 1%;
-    top: 2;
     background-color: transparent;
     border: none;
-    width: fit-content;
+    width: auto;
     cursor: pointer;
-    padding: 0;
 }
 
 .eye {

--- a/src/Provider-login/LoginPage.tsx
+++ b/src/Provider-login/LoginPage.tsx
@@ -53,7 +53,6 @@ export const LoginPage: React.FC = () => {
                 throw new Error(errorData.error || errorData.message || 'Login failed');
             }
     
-            // Check for the Authorization header
             const authHeader = response.headers.get('Authorization');
             if (!authHeader) {
                 throw new Error('No Authorization header found in response');
@@ -63,7 +62,6 @@ export const LoginPage: React.FC = () => {
             sessionStorage.setItem('authToken', token);
             setToken(token);
     
-            // Parse the response body
             const data = await response.json();
             console.log('LINE 66:', data);
     

--- a/src/Provider-login/LoginPage.tsx
+++ b/src/Provider-login/LoginPage.tsx
@@ -33,7 +33,7 @@ export const LoginPage: React.FC = () => {
         e.preventDefault();
         setError('');
         setIsLoading(true);
-
+    
         try {
             const response = await fetch('https://uta-aba-finder-be-97eec9f967d0.herokuapp.com/login', {
                 method: 'POST',
@@ -47,29 +47,36 @@ export const LoginPage: React.FC = () => {
                     }
                 }),
             });
-
+    
             if (!response.ok) {
                 const errorData = await response.json();
                 throw new Error(errorData.error || errorData.message || 'Login failed');
             }
-
+    
+            // Check for the Authorization header
             const authHeader = response.headers.get('Authorization');
             if (!authHeader) {
                 throw new Error('No Authorization header found in response');
             }
-
+    
             const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : authHeader;
             sessionStorage.setItem('authToken', token);
             setToken(token);
-
+    
+            // Parse the response body
             const data = await response.json();
-            console.log('LINE 66:', data)
+            console.log('LINE 66:', data);
+    
             const providerId = data.data.id;
-            const providerDetails = await fetchSingleProvider(providerId);
-            setCurrentProvider(providerDetails);
-            setIsLoggedIn(true);
-            setUsername('')
-            setPassword('')
+            if (providerId) {
+                const providerDetails = await fetchSingleProvider(providerId);
+                setCurrentProvider(providerDetails);
+                setIsLoggedIn(true);
+                setUsername('');
+                setPassword('');
+            } else {
+                throw new Error('Provider ID not found');
+            }
         } catch (err) {
             console.error('Login error:', err);
             setError(err instanceof Error ? err.message : 'An unexpected error occurred');
@@ -77,7 +84,8 @@ export const LoginPage: React.FC = () => {
         } finally {
             setIsLoading(false);
         }
-    }
+    };
+    
 
     const handleShowPassword = () => {
         setShowPassword(!showPassword);

--- a/src/Providers-page/ProvidersPage.css
+++ b/src/Providers-page/ProvidersPage.css
@@ -214,7 +214,6 @@
     margin-bottom: 0.5rem;
     appearance: none;
     max-width: 100%;
-    /* Limits the width to its container */
     display: inline-block;
 }
 

--- a/src/Providers-page/ProvidersPage.tsx
+++ b/src/Providers-page/ProvidersPage.tsx
@@ -43,29 +43,35 @@ const ProvidersPage: React.FC = () => {
         }
         const providersList: MockProviders = await fetchProviders();
         const mappedProviders = providersList.data.map(provider => provider.attributes);
-        setAllProviders(mappedProviders);
-        setFilteredProviders(mappedProviders);
-
+    
+        const sortedProviders = mappedProviders.sort((a, b) => {
+          const nameA = a.name ?? ''; 
+          const nameB = b.name ?? ''; 
+          return nameA.localeCompare(nameB);
+        });
+    
+        setAllProviders(sortedProviders);
+        setFilteredProviders(sortedProviders);
+    
         const uniqueInsurances = Array.from(new Set(
-          mappedProviders.flatMap(provider => provider.insurance.map(ins => ins.name || '')).sort() as string[]
+          sortedProviders.flatMap(provider => provider.insurance.map(ins => ins.name || '')).sort() as string[]
         ));
         setUniqueInsuranceOptions(uniqueInsurances);
         setMapAddress('Utah');
-        setIsLoading(false)
-        if (mappedProviders.length === 0) {
+        setIsLoading(false);
+        if (sortedProviders.length === 0) {
           errorTimeoutRef.current = setTimeout(() => {
             setShowError('We are currently experiencing issues displaying ABA Providers. Please try again later.');
-          }, 5000); // Wait 5 seconds before showing the error
+          }, 5000);
         }
       } catch (error) {
         console.error('Error loading providers:', error);
         setIsLoading(false);
         errorTimeoutRef.current = setTimeout(() => {
           setShowError('We are currently experiencing issues displaying ABA Providers. Please try again later.');
-        }, 5000); // Wait 5 seconds before showing the error
+        }, 5000);
       }
     };
-
     getProviders();
     return () => {
       if (errorTimeoutRef.current) {
@@ -114,8 +120,15 @@ const ProvidersPage: React.FC = () => {
       serviceFilter(provider) &&
       waitlistFilter(provider)
     );
-
-    setFilteredProviders(filtered);
+    
+    const sortedFilteredProviders = filtered.sort((a, b) => {
+      const nameA = a.name || ''; 
+      const nameB = b.name || '';
+      return nameA.localeCompare(nameB);
+    });
+    
+    setFilteredProviders(sortedFilteredProviders);
+    
     setIsFiltered(true);
     setCurrentPage(1);
   }, [allProviders]);
@@ -194,15 +207,23 @@ const ProvidersPage: React.FC = () => {
     }));
 
     const filteredResults = mappedResults.filter(provider =>
-      (!selectedService || (selectedService === 'telehealth' && provider.telehealth_services?.toLowerCase() === 'yes') ||
+      (!selectedService || 
+        (selectedService === 'telehealth' && provider.telehealth_services?.toLowerCase() === 'yes') ||
         (selectedService === 'at_home' && provider.at_home_services?.toLowerCase() === 'yes') ||
         (selectedService === 'in_clinic' && provider.in_clinic_services?.toLowerCase() === 'yes')) &&
-      (!selectedWaitList || (selectedWaitList === '6 Months or Less' && (provider.waitlist ? parseInt(provider.waitlist, 10) <= 6 : false)) ||
+      (!selectedWaitList || 
+        (selectedWaitList === '6 Months or Less' && (provider.waitlist ? parseInt(provider.waitlist, 10) <= 6 : false)) ||
         (selectedWaitList === 'no' && provider.waitlist?.toLowerCase() === 'no'))
     );
-
-
-    setFilteredProviders(filteredResults);
+    
+    const sortedFilteredResults = filteredResults.sort((a, b) => {
+      const nameA = a.name || ''; 
+      const nameB = b.name || '';
+      return nameA.localeCompare(nameB);
+    });
+    
+    setFilteredProviders(sortedFilteredResults);
+    
     setCurrentPage(1);
   };
 

--- a/src/Utility/ApiCall.ts
+++ b/src/Utility/ApiCall.ts
@@ -15,12 +15,12 @@ export const fetchProviders = async (): Promise<MockProviders> => {
 
 export const fetchSingleProvider = async (providerId: number) => {
   console.log("Fetching provider with ID:", providerId);
-  const token = sessionStorage.getItem('authToken'); // Retrieve the token
+  const token = sessionStorage.getItem('authToken'); 
 
   try {
     const response = await fetch(`https://uta-aba-finder-be-97eec9f967d0.herokuapp.com/api/v1/providers/${providerId}`, {
       headers: {
-        'Authorization': `Bearer ${token}`  // Include the Authorization header
+        'Authorization': `Bearer ${token}` 
       }
     });
 

--- a/src/Utility/ApiCall.ts
+++ b/src/Utility/ApiCall.ts
@@ -15,8 +15,14 @@ export const fetchProviders = async (): Promise<MockProviders> => {
 
 export const fetchSingleProvider = async (providerId: number) => {
   console.log("Fetching provider with ID:", providerId);
+  const token = sessionStorage.getItem('authToken'); // Retrieve the token
+
   try {
-    const response = await fetch(`https://uta-aba-finder-be-97eec9f967d0.herokuapp.com/api/v1/providers/${providerId}`);
+    const response = await fetch(`https://uta-aba-finder-be-97eec9f967d0.herokuapp.com/api/v1/providers/${providerId}`, {
+      headers: {
+        'Authorization': `Bearer ${token}`  // Include the Authorization header
+      }
+    });
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
**What does this PR do?**

1. Added Cypress testing to Provider Login page and User Flow.
2. Refactored getProviders to display Providers in an alphabetical order upon initial display and after being filtered by the Search Bar, so that edited Providers won't get moved to back of the array.



### To start the app

- [ ]  Clone down the repository onto your local machine using `git clone <https://github.com/utah-aba-finder/utah-aba-finder-fe`>
- [ ]  Once cloned down, cd into the direction and install dependencies by running `npm install`
- [ ]  Run `npm start` then visit the local host to view the application in your browser.

### To test with Cypress

- [ ]  Type `npm install cypress --save-dev` into your terminal
- [ ]  Type `npm run cypress #` in your terminal then visit the local host to view the application in your browser.
- [ ]  Click E2E testing
- [ ]  Click Start E2E Testing in Chrome

**Screenshots**

