### PR TITLE
Iteration7/fe/providers page styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-        "cypress": "^13.14.2"
+        "cypress": "^13.14.2",
+        "sass": "^1.79.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -11658,6 +11659,12 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "devOptional": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -18415,6 +18422,23 @@
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
     },
+    "node_modules/sass": {
+      "version": "1.79.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.3.tgz",
+      "integrity": "sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==",
+      "devOptional": true,
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/sass-loader": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
@@ -18450,6 +18474,34 @@
         "sass-embedded": {
           "optional": true
         }
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "devOptional": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+      "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+      "devOptional": true,
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/sax": {
@@ -29697,6 +29749,12 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
       "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA=="
     },
+    "immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "devOptional": true
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -34323,6 +34381,34 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
+    },
+    "sass": {
+      "version": "1.79.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.3.tgz",
+      "integrity": "sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==",
+      "devOptional": true,
+      "requires": {
+        "chokidar": "^4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "dependencies": {
+        "chokidar": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+          "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+          "devOptional": true,
+          "requires": {
+            "readdirp": "^4.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+          "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+          "devOptional": true
+        }
+      }
     },
     "sass-loader": {
       "version": "12.6.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "cypress": "^13.14.2"
+    "cypress": "^13.14.2",
+    "sass": "^1.79.3"
   }
 }

--- a/src/App/App.css
+++ b/src/App/App.css
@@ -20,3 +20,22 @@ body {
   padding-top: 1rem;
   padding-bottom: 1rem;
 }
+
+.grid {
+  display: grid;
+}
+
+.title {
+  font-family: "Gotham", sans-serif;
+  color: #424266;
+  font-weight: 700;
+}
+
+.text {
+  text-align: center;
+  text-align: right;
+  text-align: justify;
+  font-weight: 400;
+  color: #808080;
+  line-height: 1.6;
+}

--- a/src/App/App.css
+++ b/src/App/App.css
@@ -33,9 +33,8 @@ body {
 
 .text {
   text-align: center;
-  text-align: right;
   text-align: justify;
   font-weight: 400;
-  color: #808080;
-  line-height: 1.6;
+  color: #565656;
+  
 }

--- a/src/Providers-page/ProviderCard.tsx
+++ b/src/Providers-page/ProviderCard.tsx
@@ -14,12 +14,18 @@ const ProviderCard: React.FC<ProviderCardProps> = ({ provider, onViewDetails, re
     <div className={`searched-provider-card ${provider.locations.length > 1 ? 'multiple-locations' : ''}`}>
 
       <img src={provider.logo || puzzleLogo} alt="Provider Logo" className="provider-logo" />
-      
+
       <div className="title-and-info">
         <div className="searched-provider-card-title">
           <h3>{provider.name}</h3>
           <h4>
-            {provider.locations[0]?.address_1 || 'Physical address is not available for this provider.'} {provider.locations[0]?.address_2} {provider.locations[0]?.city} {provider.locations[0]?.state} {provider.locations[0]?.zip}
+            {provider.locations[0]?.address_1
+              ? `${provider.locations[0]?.address_1}${provider.locations[0]?.address_2 ? ', ' : ''}`
+              : 'Physical address is not available for this provider.'}
+            {provider.locations[0]?.address_2 && `${provider.locations[0]?.address_2}, `}
+            {provider.locations[0]?.city && `${provider.locations[0]?.city}, `}
+            {provider.locations[0]?.state && `${provider.locations[0]?.state} `}
+            {provider.locations[0]?.zip && `${provider.locations[0]?.zip}`}
           </h4>
         </div>
         <div className="searched-provider-card-info">

--- a/src/Providers-page/ProviderCard.tsx
+++ b/src/Providers-page/ProviderCard.tsx
@@ -12,8 +12,9 @@ interface ProviderCardProps {
 const ProviderCard: React.FC<ProviderCardProps> = ({ provider, onViewDetails, renderViewOnMapButton }) => {
   return (
     <div className={`searched-provider-card ${provider.locations.length > 1 ? 'multiple-locations' : ''}`}>
-      <img src={provider.logo || puzzleLogo} alt="Provider Logo" className="provider-logo" />
 
+      <img src={provider.logo || puzzleLogo} alt="Provider Logo" className="provider-logo" />
+      
       <div className="title-and-info">
         <div className="searched-provider-card-title">
           <h3>{provider.name}</h3>

--- a/src/Providers-page/ProviderModal.css
+++ b/src/Providers-page/ProviderModal.css
@@ -1,3 +1,5 @@
+
+
 .modal-overlay {
   position: fixed;
   top: 0;
@@ -9,59 +11,58 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  
+  /* Start with the modal being invisible and slightly down */
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+/* Show modal with fade-in and slide-up */
+.modal-overlay.show {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .modal-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   background-color: rgb(227, 227, 227);
+  border-radius: 15px;
+  margin: 1em;
+  overflow: hidden;
 }
 
-.modal-grid .modal-grid-text {
-  padding: 32px;
+.modal-grid-text {
+  height: 650px;
+  padding: 25px;
+  overflow-y: auto;
 }
 
-@media (max-width: 1024px) {
-  .modal-grid .modal-grid-text {
-    padding: 24px;
-  }
+.modal-container {
+  position: relative; 
+}
+.close-button {
+  position: absolute;
+  top: 20px; 
+  right: 30px; 
+  background: transparent;
+  border: none;
+  font-size: 35px;
+  cursor: pointer;
+  color: #4e1818; 
 }
 
-.modal-grid .modal-grid-map {
-  height: auto;
+.close-button:hover {
+  color: #ff0000; 
 }
 
-@media (max-width: 1024px) {
-  .modal-grid .modal-grid-map {
-    height: 350px;
-  }
-}
-
-@media (max-width: 768px) {
-  .modal-grid .modal-grid-img {
-    height: 280px;
-  }
-}
-
-@media (max-width: 576px) {
-  .modal-grid .modal-grid-map {
-    height: 200px;
-  }
-}
-
-.modal-grid .modal-footer {
-  color: blue;
-}
-
-@media (max-width: 1024px) {
-  .modal-grid {
-    height: auto;
-    grid-template-columns: repeat(1, 1fr);
-  }
+.modal-grid-text strong {
+  color: #424266;
 }
 
 .modal-img {
-  width: 50%;
+  width: 30%;
   border-radius: 15px;
   height: auto;
   justify-content: center;
@@ -69,16 +70,361 @@
   object-fit: contain;
 }
 
+.provider-details {
+  grid-template-columns: 40px auto;
+  text-align: left;
+}
+
+.provider-details p {
+  margin-bottom: 4px;
+  line-height: 1;
+}
+
+.provider-address-phone svg {
+  vertical-align: middle;
+}
+
+.last-update {
+  padding-left: 16px;
+  margin-top: .5px;
+  margin-bottom: 0;
+  line-height: 1;
+}
+
+.website-update-container {
+  display: flex;
+  gap: 7.5rem;
+  align-items: center;
+}
+
+.email-update-container {
+  display: flex;
+  gap: 19.5rem;
+  align-items: center;
+}
+
+.counties-update-container {
+  display: flex;
+  gap: 11rem;
+  align-items: center;
+}
+
+.ages-update-container {
+  display: flex;
+  gap: 3rem;
+  align-items: center;
+}
+
+.waitlist-update-container {
+  display: flex;
+  gap: 3rem;
+  align-items: center;
+}
+
+.telehealth-update-container {
+  display: flex;
+  gap: 3rem;
+  align-items: center;
+}
+
+.athome-update-container {
+  display: flex;
+  gap: 3rem;
+  align-items: center;
+}
+
+.inclinic-update-container {
+  display: flex;
+  gap: 3rem;
+  align-items: center;
+}
+
+.spanish-update-container {
+  display: flex;
+  gap: 3rem;
+  align-items: center;
+}
+
+.insurance-update-container {
+  display: flex;
+  gap: 3rem;
+  align-items: center;
+}
+
+@media (max-width: 1024px) {
+  .modal-grid {
+    grid-template-columns: repeat(1, 1fr);
+    overflow: hidden;
+  }
+
+  .modal-grid-text {
+    height: 650px;
+    padding: 24px;
+
+  }
+
+  .modal-img {
+    width: 16%;
+  }
+
+  .modal-grid-map {
+    height: 23em;
+  }
+}
+
+@media (max-width: 1024px) and (max-height: 1366px) {
+  .modal-grid-map {
+    height: 25em;
+  }
+
+  .modal-container {
+    max-height: 100vh;
+  }
+
+  .modal-grid-text {
+    height: 20em;
+    overflow-y: auto;
+  }
+  .modal-grid {
+    height: auto;
+  }
+
+  .modal-img {
+    width: 25%;
+  }
+}
+
+@media (max-width: 820px) and (max-height: 1180px) {
+  .modal-grid-map {
+    height: 20em;
+  }
+
+  .modal-grid {
+    height: 55em;
+    overflow: hidden;
+  }
+
+  .modal-container {
+    max-height: 100vh;
+  }
+
+  .modal-grid {
+    height: auto;
+  }
+
+
+  .modal-grid-text {
+    height: 25em;
+  }
+
+  .modal-img {
+    width: 25%;
+  }
+}
+
+
+@media (max-width: 768px) {
+  .modal-grid-img {
+    height: 280px;
+  }
+
+  .modal-grid-map {
+    height: 20em;
+  }
+  .modal-grid {
+    height: auto;
+  }
+
+}
+
+@media (max-width: 576px) {
+  .modal-grid-map {
+    height: 20em;
+  }
+
+  
+
+  .modal-container {
+    max-height: 100vh;
+  }
+
+  .modal-grid {
+    height: 48em;
+  }
+
+
+}
+
+@media (max-width: 430px) {
+  .modal-grid-map {
+    height: 20em;
+  }
+
+  .modal-grid {
+    height: 47em;
+  }
+
+  .modal-container {
+    max-height: 100vh;
+  }
+
+  .modal-img {
+    width: 25%;
+  }
+
+}
+
+@media (max-width: 414px) {
+  .modal-grid-map {
+    height: 18em;
+  }
+
+  .modal-grid {
+    height: auto;
+  }
+
+ 
+
+}
+
+@media (max-width: 390px) and (max-height: 844px) {
+  .modal-grid-map {
+    height: 20em;
+  }
+
+  .modal-grid {
+    height: 52em;
+  }
+
+  .modal-grid-text {
+    height: 28em;
+  }
+
+  .modal-img {
+    width: 25%;
+  }
+}
+
+@media (max-width: 540px) and (max-height: 720px) {
+  .modal-grid-map {
+    height: 20em;
+  }
+
+  .modal-grid {
+    height: 42.5em;
+  }
+
+  .modal-grid-text {
+    height: 19em;
+  }
+
+  .modal-img {
+    width: 20%;
+  }
+}
+
+@media (max-width: 375px) {
+  .modal-grid-map {
+    height: 18em;
+  }
+
+  .modal-grid {
+    height: 40em;
+  }
+
+  .modal-grid-text {
+    height: 20em;
+  }
+
+  .modal-img {
+    width: 25%;
+  }
+}
+
+@media (max-width: 667px) and (max-height: 375px) {
+  .modal-grid {
+    grid-template-columns: 1fr;
+    height: 50em;
+  }
+
+  .modal-grid-map {
+    height: 19em;
+  }
+  .modal-grid-text {
+    height: 29em;
+  }
+
+  .modal-container {
+
+    max-height: 100vh;
+
+    overflow-y: auto;
+  }
+}
+
+@media (max-width: 932px) and (max-height: 430px) {
+  .modal-grid {
+    grid-template-columns: 1fr;
+
+  }
+
+  .modal-grid-map {
+    height: 19em;
+  }
+
+  .modal-container {
+    max-height: 100vh;
+    overflow-y: auto;
+  }
+}
+
+@media (max-width: 896px) and (max-height: 414px) {
+  .modal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .modal-container {
+    max-height: 100vh;
+    overflow-y: auto;
+  }
+}
+
+/* font sizes */
 .provider-name {
-  font-size: 36px;
+  font-size: 32px;
   margin-top: 16px;
   margin-bottom: 32px;
+  border-bottom: 1px solid #9ea3a8;
+  padding-bottom: 8px;
 }
+
+.provider-main-info {
+  border-bottom: 1px solid #9ea3a8;
+  padding-bottom: 8px;
+}
+
+.last-update {
+  font-style: italic;
+  font-weight: 300;
+  font-size: 12px;
+  padding-left: 20px;
+  display: flex;
+}
+
+/* font sizes for multiple screens */
 
 @media (max-width: 1024px) {
   .provider-name {
     font-size: 28px;
     margin-bottom: 24px;
+  }
+
+  .provider-address-phone {
+    font-size: 17px;
+  }
+
+  .provider-details {
+    font-size: 15px;
   }
 }
 
@@ -86,39 +432,28 @@
   .provider-name {
     font-size: 22px;
   }
-}
 
-.provider-address-phone {
-  font-size: 18px;
-}
-
-
-@media (max-width: 1024px) {
   .provider-address-phone {
     font-size: 16px;
   }
-}
 
-@media (max-width: 576px) {
-  .provider-address-phone {
-    font-size: 15px;
+  .provider-details {
+    font-size: 13px;
   }
 }
 
-.modal-footer {
-  justify-content: space-between;
-  display: flex;
-  align-items: center;
+
+@media (max-width: 576px) {
+  .provider-address-phone {
+    font-size: 14px;
+  }
+
+  .provider-details {
+    font-size: 12px;
+  }
+
 }
 
-.provider-details-section .grid {
-  grid-template-columns: 40px auto;
-  column-gap: 12px;
-  text-align: right;
-}
-.provider-details {
-  text-align: left;
-}
 
 /* multiple locations */
 .provider-address-phone .multiple-locations {

--- a/src/Providers-page/ProviderModal.css
+++ b/src/Providers-page/ProviderModal.css
@@ -11,176 +11,129 @@
   z-index: 1000;
 }
 
-.modal-content {
-  background-color: #fff;
-  border-radius: 16px;
-  padding: 2rem;
-  width: 90%;
-  max-width: 700px;
-  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
-  position: relative;
-  z-index: 1001;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  animation: fadeIn 0.4s ease-in-out;
+.modal-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  background-color: rgb(227, 227, 227);
 }
 
-.modal-close {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  background-color: transparent;
-  border: none;
-  font-size: 1.5rem;
-  color: #666;
-  cursor: pointer;
-  transition: color 0.3s ease;
+.modal-grid .modal-grid-text {
+  padding: 32px;
 }
 
-.modal-close:hover {
-  color: #E74C3C;
+@media (max-width: 1024px) {
+  .modal-grid .modal-grid-text {
+    padding: 24px;
+  }
 }
 
-.provider-page-modal-provider-logo {
-  width: 20%;
+.modal-grid .modal-grid-map {
   height: auto;
-  border-radius: 14px;
-  margin-bottom: 1rem;
 }
 
-.location-info {
-  max-width: 100%;
+@media (max-width: 1024px) {
+  .modal-grid .modal-grid-map {
+    height: 350px;
+  }
 }
 
-.company-info {
-  text-align: center;
+@media (max-width: 768px) {
+  .modal-grid .modal-grid-img {
+    height: 280px;
+  }
 }
 
-.company-info h2 {
-  font-size: 1.8rem;
-  margin: 0.5rem 0;
-  color: #333;
+@media (max-width: 576px) {
+  .modal-grid .modal-grid-map {
+    height: 200px;
+  }
 }
 
-.company-info h3 {
-  font-size: 1rem;
-  margin: 0.5rem 0;
-  color: #777;
+.modal-grid .modal-footer {
+  color: blue;
 }
 
-.contact-info {
-  text-align: center;
-  margin-bottom: 1.5rem;
+@media (max-width: 1024px) {
+  .modal-grid {
+    height: auto;
+    grid-template-columns: repeat(1, 1fr);
+  }
 }
 
-.contact-info p {
-  margin: 0.3rem 0;
-  font-size: 1rem;
-  color: #707070;
+.modal-img {
+  width: 50%;
+  border-radius: 15px;
+  height: auto;
+  justify-content: center;
+  align-items: center;
+  object-fit: contain;
 }
 
-.contact-info.smaller-font {
-  font-size: 0.85rem;
+.provider-name {
+  font-size: 36px;
+  margin-top: 16px;
+  margin-bottom: 32px;
 }
 
-.details {
-  width: 100%;
-  max-width: 600px;
-  background-color: white;
-  padding: 1rem;
-  border-radius: 8px;
-  box-shadow: 1px 3px rgba(0, 0, 0, 0.1);
+@media (max-width: 1024px) {
+  .provider-name {
+    font-size: 28px;
+    margin-bottom: 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .provider-name {
+    font-size: 22px;
+  }
+}
+
+.provider-address-phone {
+  font-size: 18px;
+}
+
+
+@media (max-width: 1024px) {
+  .provider-address-phone {
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 576px) {
+  .provider-address-phone {
+    font-size: 15px;
+  }
+}
+
+.modal-footer {
+  justify-content: space-between;
+  display: flex;
+  align-items: center;
+}
+
+.provider-details-section .grid {
+  grid-template-columns: 40px auto;
+  column-gap: 12px;
+  text-align: right;
+}
+.provider-details {
   text-align: left;
 }
 
-.details p {
-  font-size: 1rem;
-  margin: 0.5rem 0;
-  color: #555;
+/* multiple locations */
+.provider-address-phone .multiple-locations {
+  font-size: 17px;
 }
 
-.details strong {
-  color: #333;
-}
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: scale(0.9);
-  }
-
-  to {
-    opacity: 1;
-    transform: scale(1);
+@media (max-width: 1024px) {
+  .provider-address-phone .multiple-locations {
+    font-size: 15px;
   }
 }
 
-@media (max-width: 540px) {
-  .modal-content {
-    width: 95%;
-    max-width: 99%;
-    overflow: auto;
-  }
-
-  .provider-page-modal-provider-logo {
-    width: 100px;
-  }
-
-  .company-info {
-    max-width: 100%;
-  }
-
-  .company-info h2 {
-    font-size: 1rem;
-  }
-
-  .contact-info p {
-    font-size: 0.2rem;
-  }
-
-  .contact-info.smaller-font {
-    font-size: 0.6rem;
-  }
-
-  .company-info h3,
-  .contact-info p,
-  .details p {
-    font-size: 0.75rem;
-  }
-}
-
-/* Landscape orientation adjustments */
-@media (max-width: 1000px) and (orientation: landscape) {
-  .modal-content {
-    width: 100%;
-    
-    height: 80vh;
-    overflow-y: auto;
-    padding: 1rem;
-  }
-
-  .provider-page-modal-provider-logo {
-    width: 80px;
-  }
-
-  .company-info h2 {
-    font-size: .8rem;
-  }
-
-  .company-info .smaller-font {
-    font-size: .5rem;
-  }
-
-  .company-info {
-    font-size: .5rem;
-  }
-
-  .contact-info p {
-    font-size: 0.3rem;
-  }
-
-  .details p {
-    font-size: 0.6rem;
+@media (max-width: 576px) {
+  .provider-address-phone .multiple-locations {
+    font-size: 14px;
   }
 }

--- a/src/Providers-page/ProviderModal.tsx
+++ b/src/Providers-page/ProviderModal.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import './ProviderModal.css';
 import GoogleMap from './GoogleMap';
+import { MapPin, Phone, Globe, Mail } from 'lucide-react'
+import { useEffect, useState } from 'react';
 
 interface Location {
   name?: string | null;
@@ -36,73 +38,120 @@ interface ProviderAttributes {
 
 interface ProviderModalProps {
   provider: ProviderAttributes;
+  address: string;
+  mapAddress: string;
   onClose: () => void;
 }
 
-const ProviderModal: React.FC<ProviderModalProps> = ({ provider, onClose }) => {
+const ProviderModal: React.FC<ProviderModalProps> = ({ provider, address, mapAddress, onClose }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    // Trigger the modal to appear with animation
+    setTimeout(() => setIsVisible(true), 10);
+  }, []);
   if (!provider) return null;
 
   const hasMultipleLocations = provider.locations.length > 1;
 
-
   return (
-    <div className="modal-overlay">
-      <div className="modal-grid grid">
-        <div className="modal-grid-map">
-          <GoogleMap />
-        </div>
-
-        <div className="modal-grid-text">
-          <div className="modal-logo">
-            <img src={provider.logo ?? undefined} alt={provider.name ?? undefined} className="modal-img"/>
-          </div>
-          <div>
-            <div className="status-badge">status</div>
-            <h2 className="provider-name title">
-              {provider.name}
-            </h2>
-            <p className="provider-address-phone text">
-              {provider.locations.length > 0 ? (
-                provider.locations.slice(0, 4).map((location, index) => (
-                  <p
-                    key={index}
-                    className={`provider-address-phone ${hasMultipleLocations ? 'multiple-locations' : ''}`}
-                  >
-                    <p><strong>Location {index + 1}: </strong></p>
-                    <p><strong>Address: </strong>
-                      {location.name && <span> {location.name}, </span>}
-                      {location.address_1 && <span>{location.address_1}, </span>}
-                      {location.address_2 && <span>{location.address_2}, </span>}
-                      {location.city && <span>{location.city}, </span>}
-                      {location.state && <span>{location.state} </span>}
-                      {location.zip && <span>{location.zip}</span>}
-                    </p>
-                    <p> <strong> Phone: <a href={`tel:${location.phone}`}>{location.phone}</a></strong> </p>
-
-                  </p>
-                ))
-              ) : (
-                <p><strong>Physical address is not available for this provider</strong></p>
-              )}
-            </p>
+    <div className={`modal-overlay ${isVisible ? 'show' : ''}`}>
+      <div className="modal-container">
+        <button className="close-button" onClick={onClose} aria-label="Close Modal">
+          &times;
+        </button>
+        <div className="modal-grid">
+          <div className="modal-grid-map">
+            <GoogleMap address={mapAddress} />
           </div>
 
-          <div className="modal-footer">
-            <div className="provider-details-section">
+          <div className="modal-grid-text">
+            <div className="modal-logo">
+              <img src={provider.logo ?? undefined} alt={provider.name ?? undefined} className="modal-img" />
+            </div>
+            <div className="provider-main-info">
+              <h2 className="provider-name title">{provider.name}</h2>
+              <p className="provider-address-phone text">
+                {provider.locations.length > 0 ? (
+                  provider.locations.map((location, index) => (
+                    <div key={index} className="provider-address-phone">
+                      {hasMultipleLocations && (
+                        <p><strong>Location {index + 1}: </strong></p>
+                      )}
+                      <p>
+                        <MapPin style={{ marginRight: '8px' }} />
+                        <strong>Address: </strong>
+                        {provider.locations[0]?.address_1
+                          ? `${provider.locations[0]?.address_1}${provider.locations[0]?.address_2 ? ', ' : ''}`
+                          : 'Physical address is not available for this provider.'}
+                        {provider.locations[0]?.address_2 && `${provider.locations[0]?.address_2}, `}
+                        {provider.locations[0]?.city && `${provider.locations[0]?.city}, `}
+                        {provider.locations[0]?.state && `${provider.locations[0]?.state} `}
+                        {provider.locations[0]?.zip && `${provider.locations[0]?.zip}`}
+                      </p>
+                      <p>
+                        <Phone style={{ marginRight: '8px' }} />
+                        <strong>Phone: </strong><a href={`tel:${location.phone}`}>{location.phone}</a>
+                      </p>
+                      <p>
+                        <Globe style={{ marginRight: '8px' }} />
+                        <strong>Website:</strong> <a href={provider.website ?? undefined} target="_blank" rel="noopener noreferrer">{provider.website ?? 'Provider does not have a website yet.'}</a>
+                      </p>
+                      <p>
+                        <Mail style={{ marginRight: '8px' }} />
+                        <strong>Email:</strong> <a href={`mailto:${provider.email ?? ''}`} target="_blank" rel="noopener noreferrer">{provider.email ?? 'Provider does not have an email yet.'}</a>
+                      </p>
+                    </div>
+                  ))
+                ) : (
+                  <p><strong>Physical address is not available for this provider</strong></p>
+                )}
+              </p>
+            </div>
 
-              <div className="provider-details text">
-                <p className="website-text"><strong>Website:</strong> <a href={provider.website ?? undefined} target="_blank" rel="noopener noreferrer">{provider.website ?? 'N/A'}</a></p>
-                <p className="email-text"><strong>Email:</strong> <a href={`mailto:${provider.email ?? ''}`} target="_blank" rel="noopener noreferrer">{provider.email ?? 'Does not have an email'}</a></p>
+            <div className="provider-details text">
+              <p><strong>Counties Served:</strong> {provider.counties_served[0]?.county || 'Contact us'}
+              </p>
 
-                <p><strong>Counties Served:</strong> {provider.counties_served[0]?.county || 'Contact us'}</p>
-                <p><strong>Ages Served:</strong> {provider.min_age} - {provider.max_age} years</p>
-                <p><strong>Waitlist:</strong> {provider.waitlist || 'Contact us'}</p>
-                <p><strong>Telehealth Services:</strong> {provider.telehealth_services || 'Contact us'}</p>
-                <p><strong>At Home Services:</strong> {provider.at_home_services || 'Contact us'}</p>
-                <p><strong>In-Clinic Services:</strong> {provider.in_clinic_services || 'Contact us'}</p>
-                <p><strong>Spanish Speakers:</strong> {provider.spanish_speakers || 'Contact us'}</p>
-                <p><strong>Insurance:</strong> {provider.insurance.map(i => i.name).join(', ') || 'Contact us'}</p>
+              <div className="update-section">
+                <span className="last-update">Last Updated - </span>
               </div>
+
+              <p><strong>Ages Served:</strong> {provider.min_age} - {provider.max_age} years</p>
+              <div className="update-section">
+                <span className="last-update">Last Updated - </span>
+              </div>
+
+              <p><strong>Waitlist:</strong> {provider.waitlist || 'Contact us'}</p>
+              <div className="update-section">
+                <span className="last-update">Last Updated - </span>
+              </div>
+
+              <p><strong>Telehealth Services:</strong> {provider.telehealth_services || 'Contact us'}</p>
+              <div className="update-section">
+                <span className="last-update">Last Updated - </span>
+              </div>
+
+              <p><strong>At Home Services:</strong> {provider.at_home_services || 'Contact us'}</p>
+              <div className="update-section">
+                <span className="last-update">Last Updated - </span>
+              </div>
+
+              <p><strong>In-Clinic Services:</strong> {provider.in_clinic_services || 'Contact us'}</p>
+              <div className="update-section">
+                <span className="last-update">Last Updated - </span>
+              </div>
+
+              <p><strong>Spanish Speakers:</strong> {provider.spanish_speakers || 'Contact us'}</p>
+              <div className="update-section">
+                <span className="last-update">Last Updated - </span>
+              </div>
+
+              <p><strong>Insurance:</strong> {provider.insurance.map(i => i.name).join(', ') || 'Contact us'}</p>
+              <div className="update-section">
+                <span className="last-update">Last Updated - </span>
+              </div>
+
             </div>
           </div>
         </div>
@@ -112,42 +161,3 @@ const ProviderModal: React.FC<ProviderModalProps> = ({ provider, onClose }) => {
 };
 
 export default ProviderModal;
-
-
-// {/* // <h2>{provider.name}</h2>
-
-// //             {provider.locations.length > 0 ? ( */}
-//               provider.locations.slice(0, 4).map((location, index) => (
-//                 <p
-//                   key={index}
-//                   className={`contact-info ${hasMultipleLocations ? 'smaller-font' : ''}`}
-//                 >
-//                   <strong>Location {index + 1}:</strong>
-//                   {location.name && <span> {location.name}, </span>}
-//                   {location.address_1 && <span>{location.address_1}, </span>}
-//                   {location.address_2 && <span>{location.address_2}, </span>}
-//                   {location.city && <span>{location.city}, </span>}
-//                   {location.state && <span>{location.state} </span>}
-//                   {location.zip && <span>{location.zip}</span>}
-//                   {location.phone && <span> - Phone: <a href={`tel:${location.phone}`}>{location.phone}</a></span>}
-//                 </p>
-//               ))
-//             ) : (
-//               <p><strong>Physical address is not available for this provider</strong></p>
-//             )}
-
-//   <p className="website-text"><strong>Website:</strong> <a href={provider.website ?? undefined} target="_blank" rel="noopener noreferrer">{provider.website ?? 'N/A'}</a></p>
-//   <p className="email-text"><strong>Email:</strong> <a href={`mailto:${provider.email ?? ''}`} target="_blank" rel="noopener noreferrer">{provider.email ?? 'Does not have an email'}</a></p>
-// </div>
-
-// <div className="details">
-//   <p><strong>Counties Served:</strong> {provider.counties_served[0]?.county || 'Contact us'}</p>
-//   <p><strong>Ages Served:</strong> {provider.min_age} - {provider.max_age} years</p>
-//   <p><strong>Waitlist:</strong> {provider.waitlist || 'Contact us'}</p>
-//   <p><strong>Telehealth Services:</strong> {provider.telehealth_services || 'Contact us'}</p>
-//   <p><strong>At Home Services:</strong> {provider.at_home_services || 'Contact us'}</p>
-//   <p><strong>In-Clinic Services:</strong> {provider.in_clinic_services || 'Contact us'}</p>
-//   <p><strong>Spanish Speakers:</strong> {provider.spanish_speakers || 'Contact us'}</p>
-//   <p><strong>Insurance:</strong> {provider.insurance.map(i => i.name).join(', ') || 'Contact us'}</p>
-//           </div>
-//         </div>

--- a/src/Providers-page/ProviderModal.tsx
+++ b/src/Providers-page/ProviderModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './ProviderModal.css';
+import GoogleMap from './GoogleMap';
 
 interface Location {
   name?: string | null;
@@ -46,46 +47,64 @@ const ProviderModal: React.FC<ProviderModalProps> = ({ provider, onClose }) => {
 
   return (
     <div className="modal-overlay">
-      <div className="modal-content">
-        <button className="modal-close" onClick={onClose}>X</button>
-        <img src={provider.logo ?? undefined} alt={provider.name ?? undefined} className="provider-page-modal-provider-logo" />
-
-        <div className="company-info">
-          <h2>{provider.name}</h2>
-
-          {provider.locations.length > 0 ? (
-            provider.locations.slice(0, 4).map((location, index) => (
-              <p
-                key={index}
-                className={`contact-info ${hasMultipleLocations ? 'smaller-font' : ''}`}
-              >
-                <strong>Location {index + 1}:</strong>
-                {location.name && <span> {location.name}, </span>}
-                {location.address_1 && <span>{location.address_1}, </span>}
-                {location.address_2 && <span>{location.address_2}, </span>}
-                {location.city && <span>{location.city}, </span>}
-                {location.state && <span>{location.state} </span>}
-                {location.zip && <span>{location.zip}</span>}
-                {location.phone && <span> - Phone: <a href={`tel:${location.phone}`}>{location.phone}</a></span>}
-              </p>
-            ))
-          ) : (
-            <p><strong>Physical address is not available for this provider</strong></p>
-          )}
-
-          <p className="website-text"><strong>Website:</strong> <a href={provider.website ?? undefined} target="_blank" rel="noopener noreferrer">{provider.website ?? 'N/A'}</a></p>
-          <p className="email-text"><strong>Email:</strong> <a href={`mailto:${provider.email ?? ''}`} target="_blank" rel="noopener noreferrer">{provider.email ?? 'Does not have an email'}</a></p>
+      <div className="modal-grid grid">
+        <div className="modal-grid-map">
+          <GoogleMap />
         </div>
 
-        <div className="details">
-          <p><strong>Counties Served:</strong> {provider.counties_served[0]?.county || 'Contact us'}</p>
-          <p><strong>Ages Served:</strong> {provider.min_age} - {provider.max_age} years</p>
-          <p><strong>Waitlist:</strong> {provider.waitlist || 'Contact us'}</p>
-          <p><strong>Telehealth Services:</strong> {provider.telehealth_services || 'Contact us'}</p>
-          <p><strong>At Home Services:</strong> {provider.at_home_services || 'Contact us'}</p>
-          <p><strong>In-Clinic Services:</strong> {provider.in_clinic_services || 'Contact us'}</p>
-          <p><strong>Spanish Speakers:</strong> {provider.spanish_speakers || 'Contact us'}</p>
-          <p><strong>Insurance:</strong> {provider.insurance.map(i => i.name).join(', ') || 'Contact us'}</p>
+        <div className="modal-grid-text">
+          <div className="modal-logo">
+            <img src={provider.logo ?? undefined} alt={provider.name ?? undefined} className="modal-img"/>
+          </div>
+          <div>
+            <div className="status-badge">status</div>
+            <h2 className="provider-name title">
+              {provider.name}
+            </h2>
+            <p className="provider-address-phone text">
+              {provider.locations.length > 0 ? (
+                provider.locations.slice(0, 4).map((location, index) => (
+                  <p
+                    key={index}
+                    className={`provider-address-phone ${hasMultipleLocations ? 'multiple-locations' : ''}`}
+                  >
+                    <p><strong>Location {index + 1}: </strong></p>
+                    <p><strong>Address: </strong>
+                      {location.name && <span> {location.name}, </span>}
+                      {location.address_1 && <span>{location.address_1}, </span>}
+                      {location.address_2 && <span>{location.address_2}, </span>}
+                      {location.city && <span>{location.city}, </span>}
+                      {location.state && <span>{location.state} </span>}
+                      {location.zip && <span>{location.zip}</span>}
+                    </p>
+                    <p> <strong> Phone: <a href={`tel:${location.phone}`}>{location.phone}</a></strong> </p>
+
+                  </p>
+                ))
+              ) : (
+                <p><strong>Physical address is not available for this provider</strong></p>
+              )}
+            </p>
+          </div>
+
+          <div className="modal-footer">
+            <div className="provider-details-section">
+
+              <div className="provider-details text">
+                <p className="website-text"><strong>Website:</strong> <a href={provider.website ?? undefined} target="_blank" rel="noopener noreferrer">{provider.website ?? 'N/A'}</a></p>
+                <p className="email-text"><strong>Email:</strong> <a href={`mailto:${provider.email ?? ''}`} target="_blank" rel="noopener noreferrer">{provider.email ?? 'Does not have an email'}</a></p>
+
+                <p><strong>Counties Served:</strong> {provider.counties_served[0]?.county || 'Contact us'}</p>
+                <p><strong>Ages Served:</strong> {provider.min_age} - {provider.max_age} years</p>
+                <p><strong>Waitlist:</strong> {provider.waitlist || 'Contact us'}</p>
+                <p><strong>Telehealth Services:</strong> {provider.telehealth_services || 'Contact us'}</p>
+                <p><strong>At Home Services:</strong> {provider.at_home_services || 'Contact us'}</p>
+                <p><strong>In-Clinic Services:</strong> {provider.in_clinic_services || 'Contact us'}</p>
+                <p><strong>Spanish Speakers:</strong> {provider.spanish_speakers || 'Contact us'}</p>
+                <p><strong>Insurance:</strong> {provider.insurance.map(i => i.name).join(', ') || 'Contact us'}</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -93,3 +112,42 @@ const ProviderModal: React.FC<ProviderModalProps> = ({ provider, onClose }) => {
 };
 
 export default ProviderModal;
+
+
+// {/* // <h2>{provider.name}</h2>
+
+// //             {provider.locations.length > 0 ? ( */}
+//               provider.locations.slice(0, 4).map((location, index) => (
+//                 <p
+//                   key={index}
+//                   className={`contact-info ${hasMultipleLocations ? 'smaller-font' : ''}`}
+//                 >
+//                   <strong>Location {index + 1}:</strong>
+//                   {location.name && <span> {location.name}, </span>}
+//                   {location.address_1 && <span>{location.address_1}, </span>}
+//                   {location.address_2 && <span>{location.address_2}, </span>}
+//                   {location.city && <span>{location.city}, </span>}
+//                   {location.state && <span>{location.state} </span>}
+//                   {location.zip && <span>{location.zip}</span>}
+//                   {location.phone && <span> - Phone: <a href={`tel:${location.phone}`}>{location.phone}</a></span>}
+//                 </p>
+//               ))
+//             ) : (
+//               <p><strong>Physical address is not available for this provider</strong></p>
+//             )}
+
+//   <p className="website-text"><strong>Website:</strong> <a href={provider.website ?? undefined} target="_blank" rel="noopener noreferrer">{provider.website ?? 'N/A'}</a></p>
+//   <p className="email-text"><strong>Email:</strong> <a href={`mailto:${provider.email ?? ''}`} target="_blank" rel="noopener noreferrer">{provider.email ?? 'Does not have an email'}</a></p>
+// </div>
+
+// <div className="details">
+//   <p><strong>Counties Served:</strong> {provider.counties_served[0]?.county || 'Contact us'}</p>
+//   <p><strong>Ages Served:</strong> {provider.min_age} - {provider.max_age} years</p>
+//   <p><strong>Waitlist:</strong> {provider.waitlist || 'Contact us'}</p>
+//   <p><strong>Telehealth Services:</strong> {provider.telehealth_services || 'Contact us'}</p>
+//   <p><strong>At Home Services:</strong> {provider.at_home_services || 'Contact us'}</p>
+//   <p><strong>In-Clinic Services:</strong> {provider.in_clinic_services || 'Contact us'}</p>
+//   <p><strong>Spanish Speakers:</strong> {provider.spanish_speakers || 'Contact us'}</p>
+//   <p><strong>Insurance:</strong> {provider.insurance.map(i => i.name).join(', ') || 'Contact us'}</p>
+//           </div>
+//         </div>

--- a/src/Providers-page/ProvidersPage.tsx
+++ b/src/Providers-page/ProvidersPage.tsx
@@ -24,6 +24,9 @@ const ProvidersPage: React.FC = () => {
   const [selectedService, setSelectedService] = useState<string>('');
   const [selectedWaitList, setSelectedWaitList] = useState<string>('');
   const [mapAddress, setMapAddress] = useState<string>('Utah');
+  const [selectedAddress, setSelectedAddress] = useState<string | null>(null);
+
+
   const [isFiltered, setIsFiltered] = useState<boolean>(false);
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [showError, setShowError] = useState('');
@@ -139,7 +142,18 @@ const ProvidersPage: React.FC = () => {
 
   const handleProviderCardClick = (provider: ProviderAttributes) => {
     setSelectedProvider(provider);
+  
+   
+    const address = provider.locations.length > 0
+      ? `${provider.locations[0].address_1 || ''} ${provider.locations[0].address_2 || ''}, ${provider.locations[0].city || ''}, ${provider.locations[0].state || ''} ${provider.locations[0].zip || ''}`.trim()
+      : 'Address not available';
+  
+   
+    setMapAddress(address);
+    setSelectedAddress(address); 
   };
+  
+
 
   const handleViewOnMapClick = (address: string | null) => {
     setMapAddress(address || 'Utah');
@@ -383,7 +397,15 @@ const ProvidersPage: React.FC = () => {
         )}
       </div>
 
-      {selectedProvider && <ProviderModal provider={selectedProvider} onClose={handleCloseModal} />}
+      {selectedProvider && (
+        <ProviderModal
+        provider={selectedProvider}
+        address={selectedAddress || 'Address not available'} 
+        mapAddress={mapAddress}
+        onClose={handleCloseModal}
+      />
+      )}
+
     </div>
   );
 };

--- a/src/Providers-page/ProvidersPage.tsx
+++ b/src/Providers-page/ProvidersPage.tsx
@@ -43,16 +43,16 @@ const ProvidersPage: React.FC = () => {
         }
         const providersList: MockProviders = await fetchProviders();
         const mappedProviders = providersList.data.map(provider => provider.attributes);
-    
+
         const sortedProviders = mappedProviders.sort((a, b) => {
-          const nameA = a.name ?? ''; 
-          const nameB = b.name ?? ''; 
+          const nameA = a.name ?? '';
+          const nameB = b.name ?? '';
           return nameA.localeCompare(nameB);
         });
-    
+
         setAllProviders(sortedProviders);
         setFilteredProviders(sortedProviders);
-    
+
         const uniqueInsurances = Array.from(new Set(
           sortedProviders.flatMap(provider => provider.insurance.map(ins => ins.name || '')).sort() as string[]
         ));
@@ -120,15 +120,15 @@ const ProvidersPage: React.FC = () => {
       serviceFilter(provider) &&
       waitlistFilter(provider)
     );
-    
+
     const sortedFilteredProviders = filtered.sort((a, b) => {
-      const nameA = a.name || ''; 
+      const nameA = a.name || '';
       const nameB = b.name || '';
       return nameA.localeCompare(nameB);
     });
-    
+
     setFilteredProviders(sortedFilteredProviders);
-    
+
     setIsFiltered(true);
     setCurrentPage(1);
   }, [allProviders]);
@@ -207,23 +207,23 @@ const ProvidersPage: React.FC = () => {
     }));
 
     const filteredResults = mappedResults.filter(provider =>
-      (!selectedService || 
+      (!selectedService ||
         (selectedService === 'telehealth' && provider.telehealth_services?.toLowerCase() === 'yes') ||
         (selectedService === 'at_home' && provider.at_home_services?.toLowerCase() === 'yes') ||
         (selectedService === 'in_clinic' && provider.in_clinic_services?.toLowerCase() === 'yes')) &&
-      (!selectedWaitList || 
+      (!selectedWaitList ||
         (selectedWaitList === '6 Months or Less' && (provider.waitlist ? parseInt(provider.waitlist, 10) <= 6 : false)) ||
         (selectedWaitList === 'no' && provider.waitlist?.toLowerCase() === 'no'))
     );
-    
+
     const sortedFilteredResults = filteredResults.sort((a, b) => {
-      const nameA = a.name || ''; 
+      const nameA = a.name || '';
       const nameB = b.name || '';
       return nameA.localeCompare(nameB);
     });
-    
+
     setFilteredProviders(sortedFilteredResults);
-    
+
     setCurrentPage(1);
   };
 
@@ -328,6 +328,7 @@ const ProvidersPage: React.FC = () => {
           <GoogleMap address={mapAddress} />
         </section>
       </div>
+
       <section className="provider-title-section">
         <h2>
           {isFiltered


### PR DESCRIPTION
**What does this PR do?**

1. Added styling and responsiveness to the Providers Page view details Modal. Upon Modal load it will load the address of that Provider, so the User can better compare the Provider and the map location.


### To start the app

- [ ]  Clone down the repository onto your local machine using `git clone <https://github.com/utah-aba-finder/utah-aba-finder-fe`>
- [ ]  Once cloned down, cd into the direction and install dependencies by running `npm install`
- [ ]  Run `npm start` then visit the local host to view the application in your browser.

### To test with Cypress

- [ ]  Type `npm install cypress --save-dev` into your terminal
- [ ]  Type `npm run cypress #` in your terminal then visit the local host to view the application in your browser.
- [ ]  Click E2E testing
- [ ]  Click Start E2E Testing in Chrome

**Screenshots
<img width="1320" alt="Screenshot 2024-09-23 at 10 59 40 PM" src="https://github.com/user-attachments/assets/86d4766b-2b7c-403f-a195-4bbe7fa0061a">
**

