### PR TITLE
fixed issue with Provider Modal where multiple locations were only re…

### DIFF
--- a/src/Providers-page/ProviderModal.tsx
+++ b/src/Providers-page/ProviderModal.tsx
@@ -81,14 +81,15 @@ const ProviderModal: React.FC<ProviderModalProps> = ({ provider, address, mapAdd
                       <p>
                         <MapPin style={{ marginRight: '8px' }} />
                         <strong>Address: </strong>
-                        {provider.locations[0]?.address_1
-                          ? `${provider.locations[0]?.address_1}${provider.locations[0]?.address_2 ? ', ' : ''}`
+                        {location.address_1
+                          ? `${location.address_1}${location.address_2 ? ', ' : ''}`
                           : 'Physical address is not available for this provider.'}
-                        {provider.locations[0]?.address_2 && `${provider.locations[0]?.address_2}, `}
-                        {provider.locations[0]?.city && `${provider.locations[0]?.city}, `}
-                        {provider.locations[0]?.state && `${provider.locations[0]?.state} `}
-                        {provider.locations[0]?.zip && `${provider.locations[0]?.zip}`}
+                        {location.address_2 && `${location.address_2}, `}
+                        {location.city && `${location.city}, `}
+                        {location.state && `${location.state} `}
+                        {location.zip && `${location.zip}`}
                       </p>
+
                       <p>
                         <Phone style={{ marginRight: '8px' }} />
                         <strong>Phone: </strong><a href={`tel:${location.phone}`}>{location.phone}</a>


### PR DESCRIPTION
…ferencing the first location in the array, it will now display all locations

**What does this PR do?**

1. Fixed issue for Provider Modal to properly display all locations, if the Provider has multiple locations, instead of just the first location repeated.

### To start the app

- [ ]  Clone down the repository onto your local machine using `git clone <https://github.com/utah-aba-finder/utah-aba-finder-fe`>
- [ ]  Once cloned down, cd into the direction and install dependencies by running `npm install`
- [ ]  Run `npm start` then visit the local host to view the application in your browser.

### To test with Cypress

- [ ]  Type `npm install cypress --save-dev` into your terminal
- [ ]  Type `npm run cypress #` in your terminal then visit the local host to view the application in your browser.
- [ ]  Click E2E testing
- [ ]  Click Start E2E Testing in Chrome

**Screenshots**

