### PR TITLE
added continue edit button for warning modal for the provider edit page

### DIFF
--- a/src/Provider-edit/AuthModal.css
+++ b/src/Provider-edit/AuthModal.css
@@ -20,6 +20,23 @@
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
+.continue-editing-button {
+    align-self: center;
+    width: fit-content;
+    padding: 10px;
+    margin-top: 1rem;
+    border: 1px solid black;
+    border-radius: 5px;
+    background-color: white;
+    color: black;
+    cursor: pointer;
+}
+
+.continue-editing-button:hover {
+    background-color: rgb(255, 64, 0);
+    color: white;
+}   
+
 .auth-modal-content h1 {
     font-size: 1.5rem;
     color: red;

--- a/src/Provider-edit/AuthModal.tsx
+++ b/src/Provider-edit/AuthModal.tsx
@@ -26,7 +26,9 @@ export const AuthModal = ({ onClose }: AuthModalProps) => {
             <div className='auth-modal-content'>
                 <X className='close-modal' onClick={onClose} />
                 <h1>For security reasons, if you refresh the page or navigate to another page, you will be logged out.</h1>
-                <p>If you have any questions, please contact the admin at <Link to="/contact" className='authwarning-link' onClick={handleLogout}>Contact Us</Link>. Upon clicking the link, you will be logged out.</p>
+                <p>If you have any questions, please contact the admin at <Link to="/contact" className='authwarning-link' onClick={handleLogout}>Contact Us</Link>. Upon clicking the link, you will also be logged out.</p>
+                <p>To continue editing your information, please click the button below.</p>
+                <button className='continue-editing-button' onClick={handleLogout}>Continue Editing</button>
             </div>
         </div>
     );

--- a/src/Provider-edit/ProviderEdit.tsx
+++ b/src/Provider-edit/ProviderEdit.tsx
@@ -312,12 +312,15 @@ const ProviderEdit: React.FC<ProviderEditProps> = ({ loggedInProvider, clearProv
                 <h1>Welcome, {providerName}</h1>
                 <p>Last edited: {moment(loggedInProvider?.attributes.updated_last).utc().local().format('MM/DD/YYYY hh:mm:ss a')} {moment.tz.guess()}</p>
                 <button className='logoutButton' onClick={handleLogout}>Logout</button>
-                <p>For any questions to the admin, please use the contact page. <strong>You will be logged out.</strong></p>
+                <p>For any questions to the admin, please use the contact page. <strong>You will be logged out upon clicking the link.</strong></p>
                 <Link to="/contact" className='contact-link' onClick={handleLogout}>Click here to go to the contact page</Link>
             </div>
 
             <h1>Edit Your Information</h1>
             {showError ? (
+                setTimeout(() => {
+                    setShowError('');
+                }, 5000),
                 <div className='error-message'>{showError}</div>
             ) : (
                 <div className='provider-edit-form'>


### PR DESCRIPTION
**What does this PR do?**

1. Adds a button to continue editing for the providers when the warning modal pops up. 


**Where should the reviewer start?**

### To start the app

- [ ]  Clone down the repository onto your local machine using `git clone <https://github.com/utah-aba-finder/utah-aba-finder-fe`>
- [ ]  Once cloned down, cd into the direction and install dependencies by running `npm install`
- [ ]  Run `npm start` then visit the local host to view the application in your browser.

### To test with Cypress

- [ ]  Type `npm install cypress --save-dev` into your terminal
- [ ]  Type `npx cypress open` in your terminal then visit the local host to view the application in your browser.
- [ ]  Click E2E testing
- [ ]  Click Start E2E Testing in Chrome

**Screenshots**

