### PR TITLE
Fe/favorite providers page

### DIFF
--- a/src/Providers-page/ProviderModal.tsx
+++ b/src/Providers-page/ProviderModal.tsx
@@ -72,7 +72,7 @@ const ProviderModal: React.FC<ProviderModalProps> = ({ provider, address, mapAdd
             <section className="modal-logo-section">
               <div className="modal-logo">
                 <img src={provider.logo ?? undefined} alt={provider.name ?? undefined} className="modal-img" />
-              <h2 className="provider-name title">{provider.name}</h2>
+                <h2 className="provider-name title">{provider.name}</h2>
               </div>
             </section>
             <section className="modal-text-section">
@@ -110,15 +110,30 @@ const ProviderModal: React.FC<ProviderModalProps> = ({ provider, address, mapAdd
 
                         <p>
                           <Phone style={{ marginRight: '8px' }} />
-                          <strong>Phone: </strong><a href={`tel:${location.phone}`}>{location.phone}</a>
+                          <strong>Phone: </strong>
+                          {location.phone ? (
+                            <a href={`tel:${location.phone}`}>{location.phone}</a>
+                          ) : (
+                            <span>Provider does not have a number for this location yet.</span>
+                          )}
                         </p>
                         <p>
                           <Globe style={{ marginRight: '8px' }} />
-                          <strong>Website:</strong> <a href={provider.website ?? undefined} target="_blank" rel="noopener noreferrer">{provider.website ?? 'Provider does not have a website yet.'}</a>
+                          <strong>Website: </strong>
+                          {provider.website ? (
+                            <a href={provider.website} target="_blank" rel="noopener noreferrer">{provider.website}</a>
+                          ) : (
+                            <span>Provider does not have a website yet.</span>)}
                         </p>
                         <p className="email-text">
                           <Mail style={{ marginRight: '8px' }} />
-                          <strong>Email:</strong> <a href={`mailto:${provider.email ?? ''}`} target="_blank" rel="noopener noreferrer">{provider.email ?? 'Provider does not have an email yet.'}</a>
+                          <strong>Email: </strong> 
+                          {provider.email ? (
+                          <a href={`mailto:${provider.email}`} target="_blank" rel="noopener noreferrer">{provider.email}
+                          </a>  
+                          ) : (
+                            <span>Provider does not have an email yet.</span>
+                          )}
                         </p>
                       </div>
                     ))

--- a/src/Providers-page/SearchBar.css
+++ b/src/Providers-page/SearchBar.css
@@ -151,8 +151,8 @@
     font-size: 0.8rem;
 }
 
-@media (max-width: 578px) {
+@media (max-width: 431px) {
     .provider-map-searchbar input[type="text"] {
-        width: 97%;
+        width: 96%;
     }
 }


### PR DESCRIPTION
**What does this PR do?**

1. Refactored Provider Modal to display the "No Information" messages as plain text instead of a hyperlink.

**Where should the reviewer start?**

### To start the app

- [ ]  Clone down the repository onto your local machine using `git clone <https://github.com/utah-aba-finder/utah-aba-finder-fe`>
- [ ]  Once cloned down, cd into the direction and install dependencies by running `npm install`
- [ ]  Run `npm start` then visit the local host to view the application in your browser.

### To test with Cypress

- [ ]  Type `npm install cypress --save-dev` into your terminal
- [ ]  Type `npx cypress open` in your terminal then visit the local host to view the application in your browser.
- [ ]  Click E2E testing
- [ ]  Click Start E2E Testing in Chrome

**Screenshots**
<img width="722" alt="Screenshot 2024-10-09 at 6 36 37 PM" src="https://github.com/user-attachments/assets/f6dc7c1b-6b49-4b0e-93f2-790699368d05">

