### PR TITLE
Refactored Age drop down to be age groups instead of ages 0-99

### DIFF
--- a/src/Providers-page/ProviderCard.css
+++ b/src/Providers-page/ProviderCard.css
@@ -62,7 +62,7 @@
 
 .provider-logo {
     max-width: 100%;
-    border-radius: 25px;
+    border-radius: 20px;
     object-fit: contain;
     padding: 1em;
 }

--- a/src/Providers-page/ProviderModal.css
+++ b/src/Providers-page/ProviderModal.css
@@ -40,7 +40,7 @@
 }
 
 .modal-grid-map {
-  height: 65%;
+  min-height: 50%;
 }
 
 .modal-logo {

--- a/src/Providers-page/SearchBar.tsx
+++ b/src/Providers-page/SearchBar.tsx
@@ -30,7 +30,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   onReset,
   providers,
 }) => {
-  
+
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [selectedCounty, setSelectedCounty] = useState<string>('');
   const [selectedInsurance, setSelectedInsurance] = useState<string>('');
@@ -62,7 +62,18 @@ const SearchBar: React.FC<SearchBarProps> = ({
     onReset();
   };
 
-  const ageOptions = ['All Ages', ...Array.from({ length: 100 }, (_, i) => i.toString())];
+  const ageOptions = [
+    { label: 'All Ages', value: '' },
+    { label: '0-2 years', value: '0-2' },
+    { label: '3-5 years', value: '3-5' },
+    { label: '5-7 years', value: '5-7' },
+    { label: '8-10 years', value: '8-10' },
+    { label: '11-13 years', value: '11-13' },
+    { label: '13-15 years', value: '13-15' },
+    { label: '16-18 years', value: '16-18' },
+    { label: '19+ years', value: '19+' },
+  ];
+
 
   return (
     <section className="provider-map-search-section">
@@ -133,11 +144,11 @@ const SearchBar: React.FC<SearchBarProps> = ({
                 setSelectedAge(e.target.value);
                 onAgeChange(e.target.value);
               }}
-              aria-label="Select Age"
+              aria-label="Select Age Group"
             >
-              {ageOptions.map((age, index) => (
-                <option key={index} value={age === 'All Ages' ? '' : age}>
-                  {age}
+              {ageOptions.map((option, index) => (
+                <option key={index} value={option.value}>
+                  {option.label}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
**What does this PR do?**

1. Refactored Age dropdown menu to be group into age groups, ( 2 years a time ) instead of the ages being 0-99.

**Where should the reviewer start?**

### To start the app

- [ ]  Clone down the repository onto your local machine using `git clone <https://github.com/utah-aba-finder/utah-aba-finder-fe`>
- [ ]  Once cloned down, cd into the direction and install dependencies by running `npm install`
- [ ]  Run `npm start` then visit the local host to view the application in your browser.

### To test with Cypress

- [ ]  Type `npm install cypress --save-dev` into your terminal
- [ ]  Type `npx cypress open` in your terminal then visit the local host to view the application in your browser.
- [ ]  Click E2E testing
- [ ]  Click Start E2E Testing in Chrome

**Screenshots**
<img width="299" alt="Screenshot 2024-10-15 at 7 26 51 PM" src="https://github.com/user-attachments/assets/971e5005-3f12-41a2-932c-dff8f793a754">

