### PR TITLE
refactors to text to be fit in card containers

### DIFF
--- a/src/Providers-page/ProviderCard.css
+++ b/src/Providers-page/ProviderCard.css
@@ -124,7 +124,7 @@
     text-align: left;
     transition: color 0.3s ease;
     text-indent: -27px; 
-    padding-left: 27px; /
+    padding-left: 27px; 
 }
 
 .card-text h4 strong {

--- a/src/Providers-page/ProviderCard.css
+++ b/src/Providers-page/ProviderCard.css
@@ -124,17 +124,17 @@
     text-align: left;
     transition: color 0.3s ease;
     text-indent: -27px; 
-    padding-left: 27px; /* This offsets the text-indent to align the first line */
+    padding-left: 27px; /
 }
 
 .card-text h4 strong {
     display: inline-block;
-    text-indent: 0; /* Reset text-indent for the strong element */
-    margin-right: 8px; /* Add some space after the icon and "Address:" text */
+    text-indent: 0; 
+    margin-right: 8px; 
 }
 .card-text h4 svg {
     vertical-align: middle;
-    margin-right: 4px; /* Reduced from 8px to 4px to tighten up the spacing */
+    margin-right: 4px; 
 }
 
 .card-text > * {
@@ -290,7 +290,7 @@ margin-right: .3em;
     .card-text h4 {
         margin: 0;
         font-size: 0.75rem;
-        text-indent: -20px; /* Slightly smaller indent for mobile */
+        text-indent: -20px; 
         padding-left: 20px;
     }
 

--- a/src/Providers-page/ProviderCard.css
+++ b/src/Providers-page/ProviderCard.css
@@ -66,7 +66,7 @@
 
 .card-text {
     flex: 1;
-    padding: 1em;
+    padding: .8em;
     gap: .6em;
     display: flex;
     flex-direction: column;
@@ -123,13 +123,24 @@
     -webkit-box-orient: vertical;
     text-align: left;
     transition: color 0.3s ease;
+    text-indent: -27px; 
+    padding-left: 27px; /* This offsets the text-indent to align the first line */
 }
 
+.card-text h4 strong {
+    display: inline-block;
+    text-indent: 0; /* Reset text-indent for the strong element */
+    margin-right: 8px; /* Add some space after the icon and "Address:" text */
+}
 .card-text h4 svg {
     vertical-align: middle;
-    margin-right: 8px;
+    margin-right: 4px; /* Reduced from 8px to 4px to tighten up the spacing */
 }
 
+.card-text > * {
+    text-indent: -27px;
+    padding-left: 27px;
+}
 .custom-link {
     color: inherit;
     text-decoration: none;
@@ -279,6 +290,13 @@ margin-right: .3em;
     .card-text h4 {
         margin: 0;
         font-size: 0.75rem;
+        text-indent: -20px; /* Slightly smaller indent for mobile */
+        padding-left: 20px;
+    }
+
+    .card-text > * {
+        text-indent: -20px;
+        padding-left: 20px;
     }
 
     .card-logo-and-text {

--- a/src/Providers-page/SearchBar.css
+++ b/src/Providers-page/SearchBar.css
@@ -59,7 +59,7 @@
 .provider-map-searchbar input[type="text"] {
     width: 99.5%;
     border: none;
-    border-radius: .6rem;
+    border-radius: .8rem;
     font-size: 1rem;
     height: 38px;
     color: #ffffff;
@@ -77,7 +77,7 @@
 .provider-reset-button {
     width: 100%;
     border: none;
-    border-radius: .6rem;
+    border-radius: .7rem;
     font-size: 1rem;
     height: 40px;
     padding-left: .4em;


### PR DESCRIPTION
**What does this PR do?**

1. Added indentation to card text containers, so that addresses are slightly more compact/readable across different screen sizes.

**Where should the reviewer start?**

### To start the app

- [ ]  Clone down the repository onto your local machine using `git clone <https://github.com/utah-aba-finder/utah-aba-finder-fe`>
- [ ]  Once cloned down, cd into the direction and install dependencies by running `npm install`
- [ ]  Run `npm start` then visit the local host to view the application in your browser.

### To test with Cypress

- [ ]  Type `npm install cypress --save-dev` into your terminal
- [ ]  Type `npx cypress open` in your terminal then visit the local host to view the application in your browser.
- [ ]  Click E2E testing
- [ ]  Click Start E2E Testing in Chrome

**Screenshots**

