### PR TITLE
Fix mobile navigation display issues

### DIFF
--- a/src/Header/Header.css
+++ b/src/Header/Header.css
@@ -52,7 +52,21 @@ header .header-nav button {
   box-shadow: none !important;
 }
 
-/* Additional spacing and responsive adjustments */
+/* Force hide desktop navigation on mobile devices */
+@media (max-width: 1023px) {
+  .header-nav {
+    display: none !important;
+  }
+}
+
+/* Ensure mobile menu button is visible on mobile */
+@media (max-width: 1023px) {
+  button[aria-label="Toggle menu"] {
+    display: block !important;
+  }
+}
+
+/* Additional spacing adjustments */
 @media (max-width: 1024px) {
   header .px-8.pr-12 {
     padding-left: 1.5rem !important;
@@ -64,15 +78,5 @@ header .header-nav button {
   header .px-8.pr-12 {
     padding-left: 1rem !important;
     padding-right: 1.5rem !important;
-  }
-}
-
-/* Ensure mobile menu button has proper spacing */
-@media (max-width: 1024px) {
-  header button[aria-label="Toggle menu"] {
-    margin-right: 0.5rem !important;
-    padding: 1.5rem !important;
-    width: 3rem !important;
-    height: 3rem !important;
   }
 } 

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -68,7 +68,7 @@ const Header = () => {
               </Link>
             </div>
 
-            {/* Desktop Navigation */}
+            {/* Desktop Navigation - Hidden on mobile */}
             <nav className="hidden lg:flex items-center space-x-5 header-nav">
               {currentNavigationItems.map((item) => (
                 <div key={item.name} className="relative group flex items-center">
@@ -129,16 +129,15 @@ const Header = () => {
               ))}
             </nav>
 
-            {/* Mobile Menu Button - Always visible on mobile */}
+            {/* Mobile Menu Button - Visible only on mobile */}
             <button
-              className="block lg:hidden p-6 relative w-12 h-12 bg-transparent border-0 hover:bg-gray-100 rounded-md transition-colors duration-200 z-10 mr-2"
+              className="lg:hidden p-6 relative w-12 h-12 bg-transparent border-0 hover:bg-gray-100 rounded-md transition-colors duration-200 z-10 mr-2"
               onClick={handleMobileMenuToggle}
               aria-label="Toggle menu"
             >
               <div className="absolute inset-0 flex items-center justify-center">
                 <div
-                  className={`w-6 h-6 relative transition-all duration-300 ${isMobileMenuOpen ? "rotate-180" : "rotate-0"
-                    }`}
+                  className={`w-6 h-6 relative transition-all duration-300 ${isMobileMenuOpen ? "rotate-180" : "rotate-0"}`}
                 >
                   <div
                     className={`absolute w-full h-0.5 bg-[#332d29] transition-all duration-300 


### PR DESCRIPTION
- Fixed mobile navbar showing desktop links instead of hamburger menu
- Simplified responsive classes: hidden lg:flex for desktop nav, lg:hidden for mobile button
- Added CSS media queries to force hide desktop navigation on mobile (max-width: 1023px)
- Ensured mobile menu button is always visible on mobile devices
- Cleaned up complex responsive classes that were causing conflicts
- Mobile navigation now properly shows hamburger menu on all mobile devices

**Did you complete the following?**

- [ ] Pull down recent changes from the main branch?
- [ ] Ensure you added all files you changed to the PR?
- [ ] Took screenshots of changes that can be seen in the browser?
- [ ] Notified the team in the Slack channel?
- [ ] Tested the changes in the browser?
- [ ] Requested a review from a team member?
- [ ] Added a description of the changes you made?
- [ ] Added a screenshot of the changes you made?

**Screenshots**

