### PR TITLE
Use PATCH/GET provider_self for provider self-service edits

### DIFF
--- a/src/Provider-edit/ProviderEdit.tsx
+++ b/src/Provider-edit/ProviderEdit.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import "react-toastify/dist/ReactToastify.css";
 import { ProviderData, ProviderAttributes } from "../Utility/Types";
+import { getApiBaseUrl } from "../Utility/config";
 import { fetchStates, fetchCountiesByState, uploadProviderLogo, removeProviderLogo, fetchPracticeTypes, PracticeType, fetchInsurance } from "../Utility/ApiCall";
 import InsuranceModal from "./InsuranceModal";
 import CountiesModal from "./CountiesModal";
@@ -509,9 +510,9 @@ const ProviderEdit: React.FC<ProviderEditProps> = ({
         return;
       }
       
-      // Use provider_self endpoint to match the PATCH endpoint and ensure primary_location_id is returned
+      // Use provider_self endpoint (self-service; no provider ID in URL)
       const response = await fetch(
-        `https://utah-aba-finder-api-c9d143f02ce8.herokuapp.com/api/v1/provider_self`,
+        `${getApiBaseUrl()}/api/v1/provider_self`,
         {
           headers: {
             'Authorization': `Bearer ${currentUser?.id?.toString() || ''}`,
@@ -1103,17 +1104,17 @@ const ProviderEdit: React.FC<ProviderEditProps> = ({
         throw new Error(`Invalid provider ID: ${providerId}`);
       }
 
-      // Verify the provider exists and user has access before attempting update
+      // Verify via provider_self (self-service; backend uses authenticated user's provider)
       try {
         const verifyResponse = await fetch(
-          `https://utah-aba-finder-api-c9d143f02ce8.herokuapp.com/api/v1/providers/${providerId}`,
+          `${getApiBaseUrl()}/api/v1/provider_self`,
           {
             headers: {
               'Authorization': `Bearer ${authUserId}`,
             },
           }
         );
-        
+
         if (!verifyResponse.ok) {
           if (verifyResponse.status === 401) {
             const errorText = await verifyResponse.text();
@@ -1123,27 +1124,26 @@ const ProviderEdit: React.FC<ProviderEditProps> = ({
               currentUser: currentUser,
               errorText: errorText
             });
-            throw new Error(`Unauthorized: You may not have permission to access this provider. Please ensure you are assigned to provider ID ${providerId}. Error: ${errorText}`);
+            throw new Error(`Unauthorized: You may not have permission to access this provider. Please log in again. Error: ${errorText}`);
           } else if (verifyResponse.status === 404) {
-            throw new Error(`Provider ID ${providerId} does not exist in the database`);
+            throw new Error(`Provider not found for your account`);
           } else {
             const errorText = await verifyResponse.text();
             throw new Error(`Failed to verify provider: ${verifyResponse.status} ${verifyResponse.statusText}. ${errorText}`);
           }
         }
-        
+
       } catch (verifyError) {
         throw verifyError;
       }
 
-      // Determine which endpoint to use based on what provider is being edited
-      // Use the correct provider_self endpoint as per API documentation
-      const apiEndpoint = 'https://utah-aba-finder-api-c9d143f02ce8.herokuapp.com/api/v1/provider_self';
+      // Self-service: PATCH provider_self (no provider ID in URL)
+      const apiEndpoint = `${getApiBaseUrl()}/api/v1/provider_self`;
       
 
       const requestBody = {
         data: [{
-          id: providerId, // Add the provider ID so backend knows which provider to update
+          id: providerId,
           attributes: cleanedAttributes,
         }]
       };

--- a/src/Provider-edit/components/CreateLocation.tsx
+++ b/src/Provider-edit/components/CreateLocation.tsx
@@ -15,7 +15,7 @@ import {
 } from "../../Utility/Types";
 import { fetchStates, fetchCountiesByState, fetchPracticeTypes, PracticeType } from "../../Utility/ApiCall";
 import { Building2, MapPin, Phone, X } from 'lucide-react';
-import { getAdminAuthHeader } from "../../Utility/config";
+import { getApiBaseUrl } from "../../Utility/config";
 import { useAuth } from "../../Provider-login/AuthProvider";
 
 // Valid waitlist options for in_home_waitlist and in_clinic_waitlist
@@ -130,23 +130,25 @@ const CreateLocation: React.FC<CreateLocationProps> = ({
         throw new Error('No user ID available for authorization. Please log out and log back in.');
       }
 
+      // Self-service: PATCH provider_self (no provider ID in URL)
                 const response = await fetch(
-            `https://utah-aba-finder-api-c9d143f02ce8.herokuapp.com/api/v1/providers/${provider.id}`,
+            `${getApiBaseUrl()}/api/v1/provider_self`,
             {
               method: 'PATCH',
               headers: {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${userId}`
               },
-          body: JSON.stringify({
-            data: {
-              attributes: {
-                ...provider.attributes,
-                locations: updatedLocations
-              }
+              body: JSON.stringify({
+                data: [{
+                  id: provider.id,
+                  attributes: {
+                    ...provider.attributes,
+                    locations: updatedLocations
+                  }
+                }]
+              })
             }
-          })
-        }
       );
 
       if (!response.ok) {

--- a/src/Provider-edit/components/EditLocation.tsx
+++ b/src/Provider-edit/components/EditLocation.tsx
@@ -3,6 +3,7 @@ import { toast } from "react-toastify";
 import { Building2, DollarSign, Clock, Stethoscope, Languages, Mail, Globe } from "lucide-react";
 import moment from "moment";
 import { ProviderData, ProviderAttributes, Insurance, CountiesServed, Location } from "../../Utility/Types";
+import { getApiBaseUrl } from "../../Utility/config";
 import { fetchStates, fetchCountiesByState } from "../../Utility/ApiCall";
 import { useAuth } from "../../Provider-login/AuthProvider";
 
@@ -69,42 +70,38 @@ const EditLocation: FC<EditLocationProps> = ({ provider, onUpdate }) => {
           ]
         : [];
 
-      const requestBody = {
-        data: {
-          attributes: {
-            ...formData,
-            id: provider.attributes.id,
-            provider_type,
-            insurance: selectedInsurances,
-            counties_served: selectedCounties,
-            locations: locations.map((location) => ({
-              ...location,
-              id: location.id || null,
-            })),
-            password: provider.attributes.password,
-            username: provider.attributes.username,
-            status: formData.status || provider.attributes.status,
-          },
-        },
+      const attributes = {
+        ...formData,
+        id: provider.attributes.id,
+        provider_type,
+        insurance: selectedInsurances,
+        counties_served: selectedCounties,
+        locations: locations.map((location) => ({
+          ...location,
+          id: location.id || null,
+        })),
+        password: provider.attributes.password,
+        username: provider.attributes.username,
+        status: formData.status || provider.attributes.status,
       };
 
-      
-
-      // Get user ID for authorization
       const userId = currentUser?.id?.toString();
       if (!userId) {
         throw new Error('No user ID available for authorization. Please log out and log back in.');
       }
 
+      // Self-service: PATCH provider_self (no provider ID in URL)
       const response = await fetch(
-        `https://utah-aba-finder-api-c9d143f02ce8.herokuapp.com/api/v1/providers/${provider.id}`,
+        `${getApiBaseUrl()}/api/v1/provider_self`,
         {
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",
             'Authorization': `Bearer ${userId}`,
           },
-          body: JSON.stringify(requestBody),
+          body: JSON.stringify({
+            data: [{ id: provider.id, attributes }],
+          }),
         }
       );
 
@@ -132,10 +129,10 @@ const EditLocation: FC<EditLocationProps> = ({ provider, onUpdate }) => {
         throw new Error(errorData.message || `HTTP ${response.status}: Failed to update provider`);
       }
 
-      // Only refresh data if the save was successful
+      // Refresh from provider_self (self-service)
       try {
         const refreshResponse = await fetch(
-          `https://utah-aba-finder-api-c9d143f02ce8.herokuapp.com/api/v1/providers/${provider.id}`,
+          `${getApiBaseUrl()}/api/v1/provider_self`,
           {
             method: "GET",
             headers: {
@@ -146,7 +143,6 @@ const EditLocation: FC<EditLocationProps> = ({ provider, onUpdate }) => {
         );
 
         if (!refreshResponse.ok) {
-
           // Don't throw error here, just log warning
         } else {
           const refreshedData = await refreshResponse.json();


### PR DESCRIPTION
- ProviderEdit: verify and refresh use GET provider_self; save uses PATCH provider_self
- EditLocation: PATCH and GET refresh use provider_self (array body format)
- CreateLocation: PATCH use provider_self with array body
- All use getApiBaseUrl(); no provider ID in URL per backend recommendation

**Did you complete the following?**

- [ ] Pull down recent changes from the main branch?
- [ ] Ensure you added all files you changed to the PR?
- [ ] Took screenshots of changes that can be seen in the browser?
- [ ] Notified the team in the Slack channel?
- [ ] Tested the changes in the browser?
- [ ] Requested a review from a team member?
- [ ] Added a description of the changes you made?
- [ ] Added a screenshot of the changes you made?

**Screenshots**

