### PR TITLE
fix: consolidate password reset API calls and stop duplicate emails.

### DIFF
--- a/src/ForgotPassword/ForgotPassword.tsx
+++ b/src/ForgotPassword/ForgotPassword.tsx
@@ -3,8 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { User, ArrowLeft } from 'lucide-react';
-import { testPasswordReset } from '../Utility/ApiCall';
-import { API_CONFIG } from '../Utility/config';
+import { requestPasswordReset } from '../Utility/ApiCall';
 import './ForgotPassword.css';
 
 const ForgotPassword: React.FC = () => {
@@ -61,16 +60,11 @@ const ForgotPassword: React.FC = () => {
     setIsLoading(true);
 
     try {
-      // Trim whitespace from email
       const trimmedEmail = email.trim();
-      
-      // First, test the password reset functionality
-      const testResult = await testPasswordReset(trimmedEmail);
-      
-      if (!testResult.success) {
-        
-        // Check if it's a 404 error (endpoint not found)
-        if (testResult.status === 404) {
+      const { ok, status, data } = await requestPasswordReset(trimmedEmail);
+
+      if (!ok) {
+        if (status === 404) {
           toast.error('Password reset functionality is not available. Please contact support for assistance.', {
             position: "top-center",
             autoClose: 8000,
@@ -86,102 +80,17 @@ const ForgotPassword: React.FC = () => {
               fontWeight: '500'
             }
           });
-          
-          // Show additional help information
-          setTimeout(() => {
-            toast.info('For immediate assistance, please contact the administrator or use the Contact Us page.', {
-              position: "top-center",
-              autoClose: 10000,
-              hideProgressBar: false,
-              closeOnClick: true,
-              pauseOnHover: true,
-              draggable: true,
-              progress: undefined,
-              style: {
-                background: '#3B82F6',
-                color: 'white',
-                fontSize: '16px',
-                fontWeight: '500'
-              }
-            });
-          }, 2000);
-        } else {
-          // Show generic error message
-          toast.error(`Password reset failed: ${testResult.error}`, {
-            position: "top-center",
-            autoClose: 6000,
-            hideProgressBar: false,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-            style: {
-              background: '#EF4444',
-              color: 'white',
-              fontSize: '16px',
-              fontWeight: '500'
-            }
-          });
+          return;
         }
-        return;
+
+        const errorMessage = Array.isArray(data.errors)
+          ? data.errors.join(', ')
+          : data.errors || data.message || data.error || `Failed to send password reset email (${status})`;
+        throw new Error(errorMessage);
       }
 
-      // Use the password reset endpoint
-      const endpoint = `${API_CONFIG.BASE_API_URL}/api/v1/password_resets`;
-      
-
-
-      // If test passes, proceed with the actual request
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          email: trimmedEmail
-        })
-      });
-      
-
-
-      let responseData;
-      try {
-        const responseText = await response.text();
-        
-        if (responseText) {
-          responseData = JSON.parse(responseText);
-        } else {
-          responseData = {};
-        }
-      } catch (parseError) {
-
-        throw new Error('Invalid response from server');
-      }
-
-      if (!response.ok) {
-
-        
-        // Handle specific error cases
-        if (responseData.errors) {
-          throw new Error(responseData.errors.join(', '));
-        } else if (response.status === 422) {
-          throw new Error(responseData.message || 'Invalid request. Please check your email address.');
-        } else if (response.status === 404) {
-          throw new Error('Password reset service not found. Please contact support.');
-        } else if (response.status === 500) {
-          throw new Error('Server error. Please try again later or contact support.');
-        } else {
-          throw new Error(responseData.message || responseData.error || `Failed to send password reset email (${response.status})`);
-        }
-      }
-
-      // According to API docs, both success cases return 200 status
-      // Success case 1: "Password reset instructions sent to your email"
-      // Success case 2: "If the email exists, password reset instructions have been sent"
-      if (response.ok && (responseData.message || responseData.error?.includes("If the email exists"))) {
-        // Success case - password reset instructions sent
-        setIsSubmitted(true);
-        toast.success('✅ Password reset email sent!', {
+      setIsSubmitted(true);
+      toast.success('✅ If an account exists for that email, reset instructions have been sent.', {
           position: "top-center",
           autoClose: 5000,
           hideProgressBar: false,
@@ -194,14 +103,8 @@ const ForgotPassword: React.FC = () => {
             color: 'white',
             fontSize: '16px',
             fontWeight: '500'
-          }
-        });
-        return; // Exit early since we've handled success
-      }
-
-      // If we reach here, something unexpected happened
-
-      setIsSubmitted(true);
+        }
+      });
     } catch (error) {
 
       toast.error(error instanceof Error ? error.message : '❌ Failed to send password reset email. Please try again.', {
@@ -238,7 +141,7 @@ const ForgotPassword: React.FC = () => {
               Check Your Email
             </h2>
             <p className="mt-2 text-center text-sm text-gray-600">
-              We've sent a password reset link to <strong>{email}</strong>
+              If an account exists for <strong>{email}</strong>, we sent reset instructions to that inbox.
             </p>
             <p className="mt-4 text-center text-sm text-gray-500">
               Please check your inbox and spam folder for an email from <strong>utahabalocator@gmail.com</strong>

--- a/src/PasswordReset/PasswordReset.tsx
+++ b/src/PasswordReset/PasswordReset.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { API_CONFIG } from '../Utility/config';
+import { validatePasswordResetToken, submitPasswordReset } from '../Utility/ApiCall';
 import './PasswordReset.css';
 
 const PasswordReset: React.FC = () => {
@@ -23,25 +23,14 @@ const PasswordReset: React.FC = () => {
   const resetToken = searchParams.get('reset_password_token');
 
   const validateToken = useCallback(async () => {
-    try {
-      
-      
-      const response = await fetch(`${API_CONFIG.BASE_API_URL}/api/v1/password_resets/validate_token?token=${resetToken}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+    if (!resetToken) return;
 
-      
-      
-      if (!response.ok) {
-        await response.text();
-        
+    try {
+      const { ok } = await validatePasswordResetToken(resetToken);
+
+      if (!ok) {
         toast.error('This reset link has expired. Please request a new password reset.');
         navigate('/forgot-password');
-      } else {
-
       }
     } catch (error) {
 
@@ -121,47 +110,30 @@ const PasswordReset: React.FC = () => {
     try {
 
 
-      const response = await fetch(`${API_CONFIG.BASE_API_URL}/api/v1/password_resets`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          reset_password_token: resetToken,
-          password: password,
-          password_confirmation: passwordConfirmation
-        })
-      });
+      const { ok, status, data: responseData } = await submitPasswordReset(
+        resetToken!,
+        password,
+        passwordConfirmation
+      );
 
-
-
-      let responseData;
-      try {
-        const responseText = await response.text();
-
-
-        if (responseText) {
-          responseData = JSON.parse(responseText);
-
-        } else {
-          responseData = {};
-
-        }
-      } catch (parseError) {
-
-        throw new Error('Invalid response from server');
-      }
-
-      if (!response.ok) {
+      if (!ok) {
         // Handle specific error cases
-        if (responseData.errors && responseData.errors.includes('Reset password token is invalid or expired')) {
+        const tokenExpiredMessage = 'Reset password token is invalid or expired';
+        const hasExpiredTokenError = Array.isArray(responseData.errors)
+          ? responseData.errors.includes(tokenExpiredMessage)
+          : responseData.errors === tokenExpiredMessage;
+
+        if (hasExpiredTokenError) {
           toast.error('This reset link has expired. Please request a new password reset.');
           navigate('/forgot-password');
           return;
-        } else if (response.status === 422) {
+        } else if (status === 422) {
           throw new Error('Invalid or expired reset link. Please request a new password reset.');
         } else {
-          throw new Error(responseData.message || responseData.errors || `Failed to reset password (${response.status})`);
+          const errorMessage = Array.isArray(responseData.errors)
+            ? responseData.errors.join(', ')
+            : responseData.message || responseData.errors || `Failed to reset password (${status})`;
+          throw new Error(errorMessage);
         }
       }
 

--- a/src/Utility/ApiCall.ts
+++ b/src/Utility/ApiCall.ts
@@ -1032,6 +1032,70 @@ export const removeProviderLogo = async (providerId: number, userId: string): Pr
 // Note: uploadAdminProviderLogo function has been removed and consolidated into uploadProviderLogo
 // Use uploadProviderLogo(providerId, logoFile, authToken, true) for super admin logo uploads
 
+export type PasswordResetApiResponse = {
+  message?: string;
+  errors?: string | string[];
+  error?: string;
+};
+
+async function parsePasswordResetResponse(
+  response: Response
+): Promise<PasswordResetApiResponse> {
+  const responseText = await response.text();
+  if (!responseText) return {};
+  try {
+    return JSON.parse(responseText) as PasswordResetApiResponse;
+  } catch {
+    throw new Error('Invalid response from server');
+  }
+}
+
+/** POST /api/v1/password_resets */
+export const requestPasswordReset = async (
+  email: string
+): Promise<{ ok: boolean; status: number; data: PasswordResetApiResponse }> => {
+  const response = await fetch(`${API_CONFIG.BASE_API_URL}/api/v1/password_resets`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: email.trim() }),
+  });
+  const data = await parsePasswordResetResponse(response);
+  return { ok: response.ok, status: response.status, data };
+};
+
+/** GET /api/v1/password_resets/validate_token?token=... */
+export const validatePasswordResetToken = async (
+  token: string
+): Promise<{ ok: boolean; status: number }> => {
+  const response = await fetch(
+    `${API_CONFIG.BASE_API_URL}/api/v1/password_resets/validate_token?token=${encodeURIComponent(token)}`,
+    {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+  return { ok: response.ok, status: response.status };
+};
+
+/** PATCH /api/v1/password_resets */
+export const submitPasswordReset = async (
+  resetPasswordToken: string,
+  password: string,
+  passwordConfirmation: string
+): Promise<{ ok: boolean; status: number; data: PasswordResetApiResponse }> => {
+  const response = await fetch(`${API_CONFIG.BASE_API_URL}/api/v1/password_resets`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      reset_password_token: resetPasswordToken,
+      password,
+      password_confirmation: passwordConfirmation,
+    }),
+  });
+  const data = await parsePasswordResetResponse(response);
+  return { ok: response.ok, status: response.status, data };
+};
+
 export const testPasswordReset = async (email: string): Promise<{ success: boolean; error?: string; details?: any; status?: number }> => {
   try {
     // Test 1: Check if the API endpoint is reachable


### PR DESCRIPTION
Centralize request, validate, and update helpers on the documented endpoints and remove the forgot-password pre-flight POST that sent two reset emails per submission.

**Did you complete the following?**

- [ ] Pull down recent changes from the main branch?
- [ ] Ensure you added all files you changed to the PR?
- [ ] Took screenshots of changes that can be seen in the browser?
- [ ] Notified the team in the Slack channel?
- [ ] Tested the changes in the browser?
- [ ] Requested a review from a team member?
- [ ] Added a description of the changes you made?
- [ ] Added a screenshot of the changes you made?

**Screenshots**

